### PR TITLE
create user endpoints

### DIFF
--- a/backend/api/backend_setup.py
+++ b/backend/api/backend_setup.py
@@ -12,6 +12,7 @@ from api.v1.aro.endpoints.picture_requests import picture_requests_router
 from api.v1.aro.endpoints.user import aro_user_router
 from api.v1.mcc.endpoints.aro_requests import aro_requests_router
 from api.v1.mcc.endpoints.auth import mcc_auth_router
+from api.v1.mcc.endpoints.users import mcc_users_router
 from api.v1.mcc.endpoints.commands import commands_router
 from api.v1.mcc.endpoints.main_commands import main_commands_router
 from api.v1.mcc.endpoints.status import status_router
@@ -35,6 +36,7 @@ def setup_routes(app: FastAPI) -> None:
     app.include_router(aro_requests_router, prefix=f"{mcc_prefix}/requests")
     app.include_router(main_commands_router, prefix=f"{mcc_prefix}/main-commands")
     app.include_router(mcc_auth_router, prefix=f"{mcc_prefix}/auth")
+    app.include_router(mcc_users_router, prefix=f"{mcc_prefix}/users")
     app.include_router(status_router, prefix=f"{mcc_prefix}/status")
 
 

--- a/backend/api/backend_setup.py
+++ b/backend/api/backend_setup.py
@@ -12,11 +12,11 @@ from api.v1.aro.endpoints.picture_requests import picture_requests_router
 from api.v1.aro.endpoints.user import aro_user_router
 from api.v1.mcc.endpoints.aro_requests import aro_requests_router
 from api.v1.mcc.endpoints.auth import mcc_auth_router
-from api.v1.mcc.endpoints.users import mcc_users_router
 from api.v1.mcc.endpoints.commands import commands_router
 from api.v1.mcc.endpoints.main_commands import main_commands_router
 from api.v1.mcc.endpoints.status import status_router
 from api.v1.mcc.endpoints.telemetry import telemetry_router
+from api.v1.mcc.endpoints.users import mcc_users_router
 
 
 def setup_routes(app: FastAPI) -> None:

--- a/backend/api/v1/mcc/endpoints/users.py
+++ b/backend/api/v1/mcc/endpoints/users.py
@@ -45,7 +45,7 @@ def update_me(data: dict[str, Any], user: MCCUsers = Depends(keycloak.get_curren
 @mcc_users_router.delete("/me")
 def delete_me(user: MCCUsers = Depends(keycloak.get_current_user)) -> dict[str, str]:
     """
-    Endpoint for deleting user from .
+    Endpoint for deleting user from keycloak service in use.
     """
     try:
         MCCUsersWrapper().delete_by_id(user.id)

--- a/backend/api/v1/mcc/endpoints/users.py
+++ b/backend/api/v1/mcc/endpoints/users.py
@@ -10,7 +10,7 @@ mcc_users_router = APIRouter(tags=["MCC", "Users"], dependencies=[keycloak.requi
 
 
 @mcc_users_router.get("/me")
-def get_me(user: MCCUsers = Depends(keycloak.get_current_user)) -> dict:
+def get_me(user: MCCUsers = Depends(keycloak.get_current_user)) -> dict[str, Any]:
     """
     Login endpoint for redirecting to keycloak's login/registration page
     """
@@ -24,7 +24,7 @@ def get_me(user: MCCUsers = Depends(keycloak.get_current_user)) -> dict:
 
 
 @mcc_users_router.patch("/me")
-def update_me(data: dict[str, Any], user: MCCUsers = Depends(keycloak.get_current_user)) -> dict:
+def update_me(data: dict[str, Any], user: MCCUsers = Depends(keycloak.get_current_user)) -> dict[str, Any]:
     """
     Callback endpoint redirected to by keycloak for tokens
     """
@@ -36,6 +36,8 @@ def update_me(data: dict[str, Any], user: MCCUsers = Depends(keycloak.get_curren
         raise HTTPException(status_code=422, detail="Field type mismatch")
     except RuntimeError:
         raise HTTPException(status_code=500, detail="Failed to update user")
+
+    keycloak.sync_user_changes(user.id, data)
 
     return get_me(user)
 
@@ -50,4 +52,5 @@ def delete_me(user: MCCUsers = Depends(keycloak.get_current_user)) -> dict[str, 
     except ValueError:
         raise HTTPException(status_code=404, detail="User not found")
 
+    keycloak.sync_user_deletion(user.id)
     return {"status": "success"}

--- a/backend/api/v1/mcc/endpoints/users.py
+++ b/backend/api/v1/mcc/endpoints/users.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+from data.data_wrappers.wrappers import MCCUsersWrapper
+from data.tables.mcc_user_tables import MCCUsers
+from fastapi import APIRouter, Depends
+from fastapi.exceptions import HTTPException
+from mcc_keycloak.client import keycloak
+
+mcc_users_router = APIRouter(tags=["MCC", "Users"], dependencies=[keycloak.require_auth])
+
+
+@mcc_users_router.get("/me")
+def get_me(user: MCCUsers = Depends(keycloak.get_current_user)) -> dict:
+    """
+    Login endpoint for redirecting to keycloak's login/registration page
+    """
+    return {
+        "id": str(user.id),
+        "email": user.email,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "phone_number": user.phone_number,
+    }
+
+
+@mcc_users_router.patch("/me")
+def update_me(data: dict[str, Any], user: MCCUsers = Depends(keycloak.get_current_user)) -> dict:
+    """
+    Callback endpoint redirected to by keycloak for tokens
+    """
+    try:
+        MCCUsersWrapper().update(user.id, data)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="User not found or field unavailable")
+    except TypeError:
+        raise HTTPException(status_code=422, detail="Field type mismatch")
+    except RuntimeError:
+        raise HTTPException(status_code=500, detail="Failed to update user")
+
+    return get_me(user)
+
+
+@mcc_users_router.delete("/me")
+def delete_me(user: MCCUsers = Depends(keycloak.get_current_user)) -> dict[str, str]:
+    """
+    Endpoint for deleting user from .
+    """
+    try:
+        MCCUsersWrapper().delete_by_id(user.id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    return {"status": "success"}

--- a/backend/api/v1/mcc/endpoints/users.py
+++ b/backend/api/v1/mcc/endpoints/users.py
@@ -30,12 +30,12 @@ def update_me(data: dict[str, Any], user: MCCUsers = Depends(keycloak.get_curren
     """
     try:
         MCCUsersWrapper().update(user.id, data)
-    except ValueError:
-        raise HTTPException(status_code=404, detail="User not found or field unavailable")
-    except TypeError:
-        raise HTTPException(status_code=422, detail="Field type mismatch")
-    except RuntimeError:
-        raise HTTPException(status_code=500, detail="Failed to update user")
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail="User not found or field unavailable") from e
+    except TypeError as e:
+        raise HTTPException(status_code=422, detail="Field type mismatch") from e
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail="Failed to update user") from e
 
     keycloak.sync_user_changes(user.id, data)
 
@@ -49,8 +49,8 @@ def delete_me(user: MCCUsers = Depends(keycloak.get_current_user)) -> dict[str, 
     """
     try:
         MCCUsersWrapper().delete_by_id(user.id)
-    except ValueError:
-        raise HTTPException(status_code=404, detail="User not found")
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail="User not found") from e
 
     keycloak.sync_user_deletion(user.id)
     return {"status": "success"}

--- a/backend/api/v1/mcc/endpoints/users.py
+++ b/backend/api/v1/mcc/endpoints/users.py
@@ -1,33 +1,44 @@
-from typing import Any
-
 from data.data_wrappers.wrappers import MCCUsersWrapper
 from data.tables.mcc_user_tables import MCCUsers
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 from mcc_keycloak.client import keycloak
 
+from api.v1.mcc.models.requests import UpdateUserRequest
+from api.v1.mcc.models.responses import UserInformationResponse
+
 mcc_users_router = APIRouter(tags=["MCC", "Users"], dependencies=[keycloak.require_auth])
 
 
 @mcc_users_router.get("/me")
-def get_me(user: MCCUsers = Depends(keycloak.get_current_user)) -> dict[str, Any]:
+def get_me(user: MCCUsers = Depends(keycloak.get_current_user)) -> UserInformationResponse:
     """
     Login endpoint for redirecting to keycloak's login/registration page
     """
-    return {
-        "id": str(user.id),
-        "email": user.email,
-        "first_name": user.first_name,
-        "last_name": user.last_name,
-        "phone_number": user.phone_number,
-    }
+    return UserInformationResponse(
+        id=str(user.id),
+        email=user.email,
+        first_name=user.first_name,
+        last_name=user.last_name,
+        phone_number=user.phone_number,
+    )
 
 
 @mcc_users_router.patch("/me")
-def update_me(data: dict[str, Any], user: MCCUsers = Depends(keycloak.get_current_user)) -> dict[str, Any]:
+def update_me(
+    request: UpdateUserRequest, user: MCCUsers = Depends(keycloak.get_current_user)
+) -> UserInformationResponse:
     """
     Callback endpoint redirected to by keycloak for tokens
     """
+
+    data = {
+        "email": request.email,
+        "first_name": request.first_name,
+        "last_name": request.last_name,
+        "phone_number": request.phone_number,
+    }
+
     try:
         MCCUsersWrapper().update(user.id, data)
     except ValueError as e:

--- a/backend/api/v1/mcc/models/requests.py
+++ b/backend/api/v1/mcc/models/requests.py
@@ -23,3 +23,14 @@ class UpdateCommandRequest(BaseModel):
     status: Annotated[CommandStatus | None, Field(description="New command lifecycle status")] = None
     type_: Annotated[int | None, Field(description="Replacement MainCommand ID")] = None
     params: Annotated[str | None, Field(description="Replacement serialized command parameters")] = None
+
+
+class UpdateUserRequest(BaseModel):
+    """
+    Request model for partially updating an existing user
+    """
+
+    email: str | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+    phone_number: str | None = None

--- a/backend/api/v1/mcc/models/responses.py
+++ b/backend/api/v1/mcc/models/responses.py
@@ -1,4 +1,5 @@
 from typing import Annotated
+from uuid import UUID
 
 from data.tables.main_tables import MainCommand
 from data.tables.transactional_tables import Commands
@@ -50,3 +51,16 @@ class SatelliteStatusResponse(BaseModel):
     last_contact: str
     session_duration: str
     telemetry_data: list[TelemetryDataResponse]
+
+
+class UserInformationResponse(BaseModel):
+    """
+
+    The User Personal Account Details Response model
+    """
+
+    id: UUID
+    email: str
+    first_name: str | None = None
+    last_name: str | None = None
+    phone_number: str | None = None

--- a/backend/mcc_keycloak/client.py
+++ b/backend/mcc_keycloak/client.py
@@ -123,4 +123,5 @@ class KeycloakClient:
         except ValueError as e:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found") from e
 
+
 keycloak = KeycloakClient(settings.keycloak)

--- a/backend/mcc_keycloak/client.py
+++ b/backend/mcc_keycloak/client.py
@@ -112,14 +112,14 @@ class KeycloakClient:
             payload[key] = data[value]
 
         try:
-            self.admin_client.update_user(user_id=user_id, payload=payload)
+            self.admin_client.update_user(user_id=str(user_id), payload=payload)
         except ValueError as e:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found") from e
 
     def sync_user_deletion(self, user_id: UUID) -> None:
         """Syncs a user deletion to the Keycloak service"""
         try:
-            self.admin_client.delete_user(user_id=user_id)
+            self.admin_client.delete_user(user_id=str(user_id))
         except ValueError as e:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found") from e
 

--- a/backend/mcc_keycloak/client.py
+++ b/backend/mcc_keycloak/client.py
@@ -9,7 +9,7 @@ from data.tables.mcc_user_tables import MCCUsers
 from fastapi import Depends, Request, status
 from fastapi.exceptions import HTTPException
 from jwcrypto.jwt import JWTExpired
-from keycloak import KeycloakError, KeycloakOpenID
+from keycloak import KeycloakAdmin, KeycloakError, KeycloakOpenID, KeycloakOpenIDConnection
 
 
 class KeycloakClient:
@@ -28,6 +28,15 @@ class KeycloakClient:
             realm_name=config.realm,
             client_id=config.client_id,
             client_secret_key=config.client_secret,
+        )
+        self.admin_client = KeycloakAdmin(
+            connection=KeycloakOpenIDConnection(
+                server_url=config.host,
+                realm_name=config.realm,
+                client_id=config.client_id,
+                client_secret_key=config.client_secret,
+                verify=True,
+            )
         )
         self.require_auth = Depends(self.authenticate)
 
@@ -91,5 +100,27 @@ class KeycloakClient:
         except ValueError as e:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found") from e
 
+    def sync_user_changes(self, user_id: UUID, data: dict[str, Any]) -> None:
+        """Syncs user information changes to the Keycloak service"""
+        payload: dict[str, Any] = {
+            "email": "email",
+            "firstName": "first_name",
+            "lastName": "last_name",
+        }
+
+        for key, value in payload.items():
+            payload[key] = data[value]
+
+        try:
+            self.admin_client.update_user(user_id=user_id, payload=payload)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found") from e
+
+    def sync_user_deletion(self, user_id: UUID) -> None:
+        """Syncs a user deletion to the Keycloak service"""
+        try:
+            self.admin_client.delete_user(user_id=user_id)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found") from e
 
 keycloak = KeycloakClient(settings.keycloak)

--- a/backend/python_test/test_mcc_users_endpoints.py
+++ b/backend/python_test/test_mcc_users_endpoints.py
@@ -9,13 +9,6 @@ from data.tables.mcc_user_tables import MCCUsers
 from main import app
 from config.config import settings
 
-# MOCK_USER = MagicMock()
-# MOCK_USER.id = UUID("E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
-# MOCK_USER.email = "test@uworbital.com"
-# MOCK_USER.first_name = "first_name"
-# MOCK_USER.last_name = "last_name"
-# MOCK_USER.phone_number = ""
-
 MOCK_USER = MCCUsers(
     id=UUID("E621E1F8-C36C-495A-93FC-0C247A3E6E5F"),
     email="test@uworbital.com",
@@ -65,13 +58,20 @@ def test_users_update_endpoint(client):
     MOCK_USER.first_name = "updated_first_name"
     MOCK_USER.last_name = "updated_last_name"
 
-    with patch.object(mcc_users.MCCUsersWrapper, "update", return_value=MOCK_USER) as mock_update:
-        response = client.patch(f"{USERS_PREFIX}/me", json={"first_name": "updated_first_name", "last_name": "updated_last_name"})
+    payload = {
+        "first_name": "updated_first_name",
+        "last_name": "updated_last_name",
+    }
+
+    with patch.object(mcc_users.MCCUsersWrapper, "update", return_value=MOCK_USER) as mock_update, \
+         patch.object(mcc_users.keycloak, "sync_user_changes", return_value=None) as mock_sync_changes:
+        response = client.patch(f"{USERS_PREFIX}/me", json=payload)
 
     assert response.status_code == 200
-    assert response.json()["first_name"] == "updated_first_name"
-    assert response.json()["last_name"] == "updated_last_name"
-    mock_update.assert_called_once_with(UUID("E621E1F8-C36C-495A-93FC-0C247A3E6E5F"), {"first_name": "updated_first_name", "last_name": "updated_last_name"})
+    assert response.json()["first_name"] == payload["first_name"]
+    assert response.json()["last_name"] == payload["last_name"]
+    mock_update.assert_called_once_with(MOCK_USER.id, payload)
+    mock_sync_changes.assert_called_once_with(MOCK_USER.id, payload)
 
     MOCK_USER.first_name = "first_name"
     MOCK_USER.last_name = "last_name"
@@ -79,8 +79,10 @@ def test_users_update_endpoint(client):
 
 def test_users_delete_endpoint(client):
     """Test that me endpoint can handle delete users by their id"""
-    with patch.object(mcc_users.MCCUsersWrapper, "delete_by_id", return_value=MOCK_USER) as mock_delete_by_id:
+    with patch.object(mcc_users.MCCUsersWrapper, "delete_by_id", return_value=MOCK_USER) as mock_delete_by_id, \
+         patch.object(mcc_users.keycloak, "sync_user_deletion", return_value=None) as mock_sync_deletion:
         response = client.delete(f"{USERS_PREFIX}/me", follow_redirects=False)
 
     assert response.status_code == 200
     mock_delete_by_id.assert_called_once_with(MOCK_USER.id)
+    mock_sync_deletion.assert_called_once_with(MOCK_USER.id)

--- a/backend/python_test/test_mcc_users_endpoints.py
+++ b/backend/python_test/test_mcc_users_endpoints.py
@@ -9,6 +9,8 @@ from data.tables.mcc_user_tables import MCCUsers
 from main import app
 from config.config import settings
 
+from api.v1.mcc.models.responses import UserInformationResponse
+
 MOCK_USER = MCCUsers(
     id=UUID("E621E1F8-C36C-495A-93FC-0C247A3E6E5F"),
     email="test@uworbital.com",
@@ -17,15 +19,16 @@ MOCK_USER = MCCUsers(
     phone_number=""
 )
 
-MOCK_USER_GET_EXPECTED = {
-    "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F".lower(),
-    "email": "test@uworbital.com",
-    "first_name": "first_name",
-    "last_name": "last_name",
-    "phone_number": ""
-}
+MOCK_USER_EXPECTED_RESPONSE = UserInformationResponse(
+    id=UUID("E621E1F8-C36C-495A-93FC-0C247A3E6E5F"),
+    email="test@uworbital.com",
+    first_name="first_name",
+    last_name="last_name",
+    phone_number=""
+)
 
 USERS_PREFIX = "/api/v1/mcc/users"
+
 
 @pytest.fixture
 def client():
@@ -41,7 +44,7 @@ def test_users_get_endpoint(client):
         response = client.get(f"{USERS_PREFIX}/me", follow_redirects=False)
 
     assert response.status_code == 200
-    assert response.json() == MOCK_USER_GET_EXPECTED
+    assert response.json() == MOCK_USER_EXPECTED_RESPONSE.model_dump(mode="json")
 
 
 def test_users_get_endpoint_unauthenticated():
@@ -52,14 +55,19 @@ def test_users_get_endpoint_unauthenticated():
 
     assert response.status_code == 401
 
+
 def test_users_update_endpoint(client):
     """Test that patch /me updates and returns the user."""
+    MOCK_USER.email = "updated_email@uworbital.com"
     MOCK_USER.first_name = "updated_first_name"
     MOCK_USER.last_name = "updated_last_name"
+    MOCK_USER.phone_number = "1234"
 
     payload = {
+        "email": "updated_email@uworbital.com",
         "first_name": "updated_first_name",
         "last_name": "updated_last_name",
+        "phone_number": "1234",
     }
 
     with patch.object(mcc_users.MCCUsersWrapper, "update", return_value=MOCK_USER) as mock_update, \
@@ -69,11 +77,15 @@ def test_users_update_endpoint(client):
     assert response.status_code == 200
     assert response.json()["first_name"] == payload["first_name"]
     assert response.json()["last_name"] == payload["last_name"]
+    assert response.json()["phone_number"] == payload["phone_number"]
     mock_update.assert_called_once_with(MOCK_USER.id, payload)
     mock_sync_changes.assert_called_once_with(MOCK_USER.id, payload)
 
+    MOCK_USER.email = "test@uworbital.com"
     MOCK_USER.first_name = "first_name"
     MOCK_USER.last_name = "last_name"
+    MOCK_USER.phone_number = ""
+
 
 def test_users_update_endpoint_failure(client):
     """Test that patch /me does not call keycloak sync if DB fails to update."""
@@ -105,6 +117,7 @@ def test_users_delete_endpoint(client):
     assert response.status_code == 200
     mock_delete_by_id.assert_called_once_with(MOCK_USER.id)
     mock_sync_deletion.assert_called_once_with(MOCK_USER.id)
+
 
 def test_users_delete_endpoint_failure(client):
     """Test that delete /me does not call keycloak sync if DB fails to update."""

--- a/backend/python_test/test_mcc_users_endpoints.py
+++ b/backend/python_test/test_mcc_users_endpoints.py
@@ -37,7 +37,6 @@ def client():
 
 def test_users_get_endpoint(client):
     """Test that get /me returns the expected user"""
-
     with patch.object(mcc_users.MCCUsersWrapper, "get_by_id", return_value=MOCK_USER):
         response = client.get(f"{USERS_PREFIX}/me", follow_redirects=False)
 
@@ -76,9 +75,29 @@ def test_users_update_endpoint(client):
     MOCK_USER.first_name = "first_name"
     MOCK_USER.last_name = "last_name"
 
+def test_users_update_endpoint_failure(client):
+    """Test that patch /me does not call keycloak sync if DB fails to update."""
+    MOCK_USER.first_name = "updated_first_name"
+    MOCK_USER.last_name = "updated_last_name"
+
+    payload = {
+        "first_name": "updated_first_name",
+        "last_name": "updated_last_name",
+    }
+
+    with patch.object(mcc_users.MCCUsersWrapper, "update", side_effect=RuntimeError()) as mock_update, \
+         patch.object(mcc_users.keycloak, "sync_user_changes", return_value=None) as mock_sync_changes:
+        response = client.patch(f"{USERS_PREFIX}/me", json=payload)
+
+    assert response.status_code == 500
+    mock_sync_changes.assert_not_called()
+
+    MOCK_USER.first_name = "first_name"
+    MOCK_USER.last_name = "last_name"
+
 
 def test_users_delete_endpoint(client):
-    """Test that me endpoint can handle delete users by their id"""
+    """Test that delete /me can handle delete users by their id."""
     with patch.object(mcc_users.MCCUsersWrapper, "delete_by_id", return_value=MOCK_USER) as mock_delete_by_id, \
          patch.object(mcc_users.keycloak, "sync_user_deletion", return_value=None) as mock_sync_deletion:
         response = client.delete(f"{USERS_PREFIX}/me", follow_redirects=False)
@@ -86,3 +105,12 @@ def test_users_delete_endpoint(client):
     assert response.status_code == 200
     mock_delete_by_id.assert_called_once_with(MOCK_USER.id)
     mock_sync_deletion.assert_called_once_with(MOCK_USER.id)
+
+def test_users_delete_endpoint_failure(client):
+    """Test that delete /me does not call keycloak sync if DB fails to update."""
+    with patch.object(mcc_users.MCCUsersWrapper, "delete_by_id", side_effect=ValueError()) as mock_delete_by_id, \
+         patch.object(mcc_users.keycloak, "sync_user_deletion", return_value=None) as mock_sync_deletion:
+        response = client.delete(f"{USERS_PREFIX}/me", follow_redirects=False)
+
+    assert response.status_code == 404
+    mock_sync_deletion.assert_not_called()

--- a/backend/python_test/test_mcc_users_endpoints.py
+++ b/backend/python_test/test_mcc_users_endpoints.py
@@ -1,0 +1,86 @@
+import pytest
+import json
+import backend.api.v1.mcc.endpoints.users as mcc_users
+from uuid import UUID
+from unittest.mock import patch, PropertyMock, MagicMock
+from mcc_keycloak.client import KeycloakClient
+from fastapi.testclient import TestClient
+from data.tables.mcc_user_tables import MCCUsers
+from main import app
+from config.config import settings
+
+# MOCK_USER = MagicMock()
+# MOCK_USER.id = UUID("E621E1F8-C36C-495A-93FC-0C247A3E6E5F")
+# MOCK_USER.email = "test@uworbital.com"
+# MOCK_USER.first_name = "first_name"
+# MOCK_USER.last_name = "last_name"
+# MOCK_USER.phone_number = ""
+
+MOCK_USER = MCCUsers(
+    id=UUID("E621E1F8-C36C-495A-93FC-0C247A3E6E5F"),
+    email="test@uworbital.com",
+    first_name="first_name",
+    last_name="last_name",
+    phone_number=""
+)
+
+MOCK_USER_GET_EXPECTED = {
+    "id": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F".lower(),
+    "email": "test@uworbital.com",
+    "first_name": "first_name",
+    "last_name": "last_name",
+    "phone_number": ""
+}
+
+USERS_PREFIX = "/api/v1/mcc/users"
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[mcc_users.keycloak.get_current_user] = lambda: MOCK_USER
+    app.dependency_overrides[mcc_users.keycloak.authenticate] = lambda: {}
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_users_get_endpoint(client):
+    """Test that get /me returns the expected user"""
+
+    with patch.object(mcc_users.MCCUsersWrapper, "get_by_id", return_value=MOCK_USER):
+        response = client.get(f"{USERS_PREFIX}/me", follow_redirects=False)
+
+    assert response.status_code == 200
+    assert response.json() == MOCK_USER_GET_EXPECTED
+
+
+def test_users_get_endpoint_unauthenticated():
+    """Test that get /me provides status code 401 when the user is not properly authenticated"""
+    client = TestClient(app)
+    with patch.object(mcc_users.MCCUsersWrapper, "get_by_id", return_value=MOCK_USER):
+        response = client.get(f"{USERS_PREFIX}/me", follow_redirects=False)
+
+    assert response.status_code == 401
+
+def test_users_update_endpoint(client):
+    """Test that patch /me updates and returns the user."""
+    MOCK_USER.first_name = "updated_first_name"
+    MOCK_USER.last_name = "updated_last_name"
+
+    with patch.object(mcc_users.MCCUsersWrapper, "update", return_value=MOCK_USER) as mock_update:
+        response = client.patch(f"{USERS_PREFIX}/me", json={"first_name": "updated_first_name", "last_name": "updated_last_name"})
+
+    assert response.status_code == 200
+    assert response.json()["first_name"] == "updated_first_name"
+    assert response.json()["last_name"] == "updated_last_name"
+    mock_update.assert_called_once_with(UUID("E621E1F8-C36C-495A-93FC-0C247A3E6E5F"), {"first_name": "updated_first_name", "last_name": "updated_last_name"})
+
+    MOCK_USER.first_name = "first_name"
+    MOCK_USER.last_name = "last_name"
+
+
+def test_users_delete_endpoint(client):
+    """Test that me endpoint can handle delete users by their id"""
+    with patch.object(mcc_users.MCCUsersWrapper, "delete_by_id", return_value=MOCK_USER) as mock_delete_by_id:
+        response = client.delete(f"{USERS_PREFIX}/me", follow_redirects=False)
+
+    assert response.status_code == 200
+    mock_delete_by_id.assert_called_once_with(MOCK_USER.id)


### PR DESCRIPTION
# Purpose
Closes #65.

# New Changes
- Implemented the /me endpoint with methods to get, update, and delete user details using the MCCUsersWraper class
- Added methods to KeycloakClient to support syncing information to the keycloak service in use
- Wrote pytests to test the basic functionality of getting, updating, and deleting user information, and the keycloak sync being called

# Testing
Explain tests that you ran to verify code functionality.
- [x] I have unit-tested this PR. Otherwise, explain why it cannot be unit-tested.
- [x] I have included screenshots of the tests performed below.

<img width="837" height="92" alt="image" src="https://github.com/user-attachments/assets/0d9aaaab-a3ac-4253-a16f-de0ff5219a1f" />

# Outstanding Changes
N/A