### PR TITLE
Wire MCC frontend to Keycloak auth

### DIFF
--- a/backend/config/cors_config.py
+++ b/backend/config/cors_config.py
@@ -8,7 +8,7 @@ class CORSConfig(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="CORS_")
 
-    allow_origins: list[str] = ["http://localhost:5173"]
+    allow_origins: list[str] = ["http://localhost:5173", "http://localhost:5174"]
     allow_credentials: bool = True
     allow_methods: list[str] = ["*"]
     allow_headers: list[str] = ["*"]

--- a/backend/python_test/test_config_manager.py
+++ b/backend/python_test/test_config_manager.py
@@ -18,7 +18,7 @@ def test_logger_config_default():
 def test_cors_config_default():
     cfg = CORSConfig()
 
-    assert cfg.allow_origins == ["http://localhost:5173"]
+    assert cfg.allow_origins == ["http://localhost:5173", "http://localhost:5174"]
     assert cfg.allow_credentials == True
     assert cfg.allow_methods == ["*"]
     assert cfg.allow_headers == ["*"]

--- a/frontend/mcc/src/App.tsx
+++ b/frontend/mcc/src/App.tsx
@@ -8,6 +8,7 @@ import Dashboard from "./pages/Dashboard";
 import AROAdmin from "./pages/AROAdmin";
 import LiveSession from "./pages/LiveSession";
 import Login from "./pages/Login";
+import { AuthProvider } from "./contexts/AuthContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import PageNotFound from "./components/PageNotFound";
 import Telemetry from "./pages/Telemetry";
@@ -18,22 +19,24 @@ import Telemetry from "./pages/Telemetry";
  */
 function App() {
   return (
-    <ThemeProvider>
-      <Nav />
-      <Background />
-      <div className="pt-16">
-        <Routes>
-          <Route path="/" element={<Dashboard />} />
-          {/* <Route path="/commands" element={<Commands />} /> */}
-          <Route path="/telemetry-data" element={<AROAdmin />} />
-          <Route path="/aro-requests" element={<LiveSession />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/telemetry" element={<Telemetry />} />
-          <Route path="*" element={<PageNotFound />} />
-        </Routes>
-      </div>
-      <ToastContainer />
-    </ThemeProvider>
+    <AuthProvider>
+      <ThemeProvider>
+        <Nav />
+        <Background />
+        <div className="pt-16">
+          <Routes>
+            <Route path="/" element={<Dashboard />} />
+            {/* <Route path="/commands" element={<Commands />} /> */}
+            <Route path="/telemetry-data" element={<AROAdmin />} />
+            <Route path="/aro-requests" element={<LiveSession />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/telemetry" element={<Telemetry />} />
+            <Route path="*" element={<PageNotFound />} />
+          </Routes>
+        </div>
+        <ToastContainer />
+      </ThemeProvider>
+    </AuthProvider>
   );
 }
 

--- a/frontend/mcc/src/App.tsx
+++ b/frontend/mcc/src/App.tsx
@@ -3,8 +3,10 @@ import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import Nav from "./components/Nav";
 import Background from "./components/Background";
+import ProtectedRoute from "./components/ProtectedRoute";
 // import Commands from "./pages/Command/Commands";
 import Dashboard from "./pages/Dashboard";
+import Commands from "./pages/Commands";
 import AROAdmin from "./pages/AROAdmin";
 import LiveSession from "./pages/LiveSession";
 import Login from "./pages/Login";
@@ -26,7 +28,7 @@ function App() {
         <div className="pt-16">
           <Routes>
             <Route path="/" element={<Dashboard />} />
-            {/* <Route path="/commands" element={<Commands />} /> */}
+            <Route path="/commands" element={<ProtectedRoute><Commands /></ProtectedRoute>} />
             <Route path="/telemetry-data" element={<AROAdmin />} />
             <Route path="/aro-requests" element={<LiveSession />} />
             <Route path="/login" element={<Login />} />

--- a/frontend/mcc/src/App.tsx
+++ b/frontend/mcc/src/App.tsx
@@ -28,7 +28,14 @@ function App() {
         <div className="pt-16">
           <Routes>
             <Route path="/" element={<Dashboard />} />
-            <Route path="/commands" element={<ProtectedRoute><Commands /></ProtectedRoute>} />
+            <Route
+              path="/commands"
+              element={
+                <ProtectedRoute>
+                  <Commands />
+                </ProtectedRoute>
+              }
+            />
             <Route path="/telemetry-data" element={<AROAdmin />} />
             <Route path="/aro-requests" element={<LiveSession />} />
             <Route path="/login" element={<Login />} />

--- a/frontend/mcc/src/components/LogoutButton.tsx
+++ b/frontend/mcc/src/components/LogoutButton.tsx
@@ -1,6 +1,6 @@
 import { API_BASE_URL } from "@/utils/api/config";
 
-export function LogoutButton() {
+function LogoutButton() {
   const handleLogout = () => {
     window.location.href = `${API_BASE_URL}/auth/logout`;
   };
@@ -14,3 +14,5 @@ export function LogoutButton() {
     </button>
   )
 }
+
+export default LogoutButton;

--- a/frontend/mcc/src/components/LogoutButton.tsx
+++ b/frontend/mcc/src/components/LogoutButton.tsx
@@ -1,0 +1,16 @@
+import { API_BASE_URL } from "@/utils/api/config";
+
+export function LogoutButton() {
+  const handleLogout = () => {
+    window.location.href = `${API_BASE_URL}/auth/logout`;
+  };
+
+  return (
+    <button
+      onClick={handleLogout}
+      className="bg-white px-4 py-2 rounded-xl text-black hover:bg-gray-200 transition-colors cursor-pointer"
+    >
+      Logout
+    </button>
+  )
+}

--- a/frontend/mcc/src/components/LogoutButton.tsx
+++ b/frontend/mcc/src/components/LogoutButton.tsx
@@ -12,7 +12,7 @@ function LogoutButton() {
     >
       Logout
     </button>
-  )
+  );
 }
 
 export default LogoutButton;

--- a/frontend/mcc/src/components/Nav.test.tsx
+++ b/frontend/mcc/src/components/Nav.test.tsx
@@ -3,27 +3,32 @@ import { render, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import "@testing-library/jest-dom";
 import Nav from "./Nav";
+import { AuthProvider } from "../contexts/AuthContext";
 import { ThemeProvider } from "../contexts/ThemeContext";
 
 describe("Nav", () => {
   it("renders logo", () => {
     render(
-      <ThemeProvider>
-        <BrowserRouter>
-          <Nav />
-        </BrowserRouter>
-      </ThemeProvider>,
+      <AuthProvider>
+        <ThemeProvider>
+          <BrowserRouter>
+            <Nav />
+          </BrowserRouter>
+        </ThemeProvider>
+      </AuthProvider>,
     );
     expect(screen.getByAltText("orbital logo")).toBeInTheDocument();
   });
 
   it("renders navigation links", () => {
     render(
-      <ThemeProvider>
-        <BrowserRouter>
-          <Nav />
-        </BrowserRouter>
-      </ThemeProvider>,
+      <AuthProvider>
+        <ThemeProvider>
+          <BrowserRouter>
+            <Nav />
+          </BrowserRouter>
+        </ThemeProvider>
+      </AuthProvider>,
     );
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
     expect(screen.getByText("Commands")).toBeInTheDocument();

--- a/frontend/mcc/src/components/Nav.tsx
+++ b/frontend/mcc/src/components/Nav.tsx
@@ -1,16 +1,17 @@
 import { Link } from "react-router-dom";
 import orbital_logo from "../assets/orbital_logo.png";
 import { NAVIGATION_LINKS } from "../utils/nav-links";
+import { useAuth } from "../contexts/AuthContext";
 import { useTheme } from "../contexts/ThemeContext";
 import SatelliteStatusIndicator from "./SatelliteStatusIndicator";
+import { LogoutButton } from "./LogoutButton";
 
 /**
  * @brief Nav component displaying the navigation bar
  * @return tsx element of Nav component
  */
 function Nav() {
-  // TODO: create user auth that checks if the user is logged in
-  const isLoggedIn = false;
+  const { isAuthenticated } = useAuth();
   const { theme, toggleTheme } = useTheme();
 
   return (
@@ -31,7 +32,7 @@ function Nav() {
 
       <div className="flex items-center gap-4">
         {/* Satellite Status Indicator - Only shown when logged in */}
-        {isLoggedIn && (
+        {isAuthenticated && (
           <SatelliteStatusIndicator
             status="online"
             lastContact="2 min ago"
@@ -90,7 +91,7 @@ function Nav() {
           )}
         </button>
 
-        {isLoggedIn ? (
+        {isAuthenticated ? (
           <Link
             to="/profile"
             className="border border-foreground/20 rounded-xl px-4 py-2 hover:bg-accent transition-colors"
@@ -105,6 +106,8 @@ function Nav() {
             Login
           </Link>
         )}
+
+        {isAuthenticated && <LogoutButton />}
       </div>
     </nav>
   );

--- a/frontend/mcc/src/components/Nav.tsx
+++ b/frontend/mcc/src/components/Nav.tsx
@@ -4,7 +4,7 @@ import { NAVIGATION_LINKS } from "../utils/nav-links";
 import { useAuth } from "../contexts/AuthContext";
 import { useTheme } from "../contexts/ThemeContext";
 import SatelliteStatusIndicator from "./SatelliteStatusIndicator";
-import { LogoutButton } from "./LogoutButton";
+import LogoutButton from "./LogoutButton";
 
 /**
  * @brief Nav component displaying the navigation bar

--- a/frontend/mcc/src/components/ProtectedRoute.tsx
+++ b/frontend/mcc/src/components/ProtectedRoute.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+
+function ProtectedRoute({ children }: { children: ReactNode }) {
+  const {isAuthenticated, isLoading} = useAuth();
+
+  if (isLoading) return <div className="text-white text-center mt-20">Loading...</div>;
+  if (!isAuthenticated) return <Navigate to="/login" replace />;
+
+  return <>{children}</>
+}
+
+export default ProtectedRoute;

--- a/frontend/mcc/src/components/ProtectedRoute.tsx
+++ b/frontend/mcc/src/components/ProtectedRoute.tsx
@@ -3,12 +3,12 @@ import { Navigate } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 
 function ProtectedRoute({ children }: { children: ReactNode }) {
-  const {isAuthenticated, isLoading} = useAuth();
+  const { isAuthenticated, isLoading } = useAuth();
 
   if (isLoading) return <div className="text-white text-center mt-20">Loading...</div>;
   if (!isAuthenticated) return <Navigate to="/login" replace />;
 
-  return <>{children}</>
+  return <>{children}</>;
 }
 
 export default ProtectedRoute;

--- a/frontend/mcc/src/contexts/AuthContext.tsx
+++ b/frontend/mcc/src/contexts/AuthContext.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { checkAuth } from "../utils/api/auth";
+
+interface AuthState {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  recheck: () => void;
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const recheck = () => {
+    setIsLoading(true);
+    checkAuth()
+      .then(setIsAuthenticated)
+      .finally(() => setIsLoading(false));
+  };
+
+  useEffect(() => {
+    recheck();
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, isLoading, recheck }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/frontend/mcc/src/pages/Commands.tsx
+++ b/frontend/mcc/src/pages/Commands.tsx
@@ -2,7 +2,7 @@ import { createColumnHelper } from "@tanstack/react-table";
 import Table from "../components/Table";
 // import SelectCommand from "./components/SelectCommand";
 // import SendCommand from "./components/SendCommand";
-import { useState } from "react";
+// import { useState } from "react";
 
 type CommandData = {
   session: string;
@@ -83,7 +83,7 @@ const data: CommandData[] = [
  * @return tsx element of Commands component
  */
 function Commands() {
-  const [selectedCommand, setSelectedCommand] = useState<string>("");
+  // const [selectedCommand, setSelectedCommand] = useState<string>("");
   const handleCommandSelect = (command: CommandData) => {
     console.log("Selected command:", command.command);
   };

--- a/frontend/mcc/src/pages/Commands.tsx
+++ b/frontend/mcc/src/pages/Commands.tsx
@@ -1,0 +1,100 @@
+import { createColumnHelper } from "@tanstack/react-table";
+import Table from "../components/Table";
+// import SelectCommand from "./components/SelectCommand";
+// import SendCommand from "./components/SendCommand";
+import { useState } from "react";
+
+type CommandData = {
+  session: string;
+  command: string;
+  status: "Pending" | "Sent" | "Responded" | "Failed";
+  type: string;
+  parameters: string;
+};
+
+const columnHelper = createColumnHelper<CommandData>();
+
+const columns = [
+  columnHelper.accessor("session", {
+    header: "Session",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("command", {
+    header: "Command",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("status", {
+    header: "Status",
+    cell: (info) => {
+      const status = info.getValue();
+      const statusColors: Record<string, string> = {
+        Pending: "text-yellow-400",
+        Sent: "text-green-400",
+        Responded: "text-blue-400",
+        Failed: "text-red-400",
+      };
+      return <span className={statusColors[status] || "text-gray-400"}>{status}</span>;
+    },
+  }),
+  columnHelper.accessor("type", {
+    header: "Type",
+    cell: (info) => info.getValue(),
+  }),
+  columnHelper.accessor("parameters", {
+    header: "Parameters",
+    cell: (info) => info.getValue(),
+  }),
+];
+
+// Demo data
+const data: CommandData[] = [
+  {
+    session: "Session 1",
+    command: "PING",
+    status: "Pending",
+    type: "Diagnostic",
+    parameters: "{}",
+  },
+  {
+    session: "Session 2",
+    command: "SET_MODE",
+    status: "Sent",
+    type: "Configuration",
+    parameters: '{"mode": "autonomous"}',
+  },
+  {
+    session: "Session 3",
+    command: "GET_STATUS",
+    status: "Responded",
+    type: "Query",
+    parameters: "{}",
+  },
+  {
+    session: "Session 4",
+    command: "DEPLOY",
+    status: "Failed",
+    type: "Action",
+    parameters: '{"component": "solar_panel_2"}',
+  },
+];
+
+/**
+ * @brief Commands component displaying the commands table
+ * @return tsx element of Commands component
+ */
+function Commands() {
+  const [selectedCommand, setSelectedCommand] = useState<string>("");
+  const handleCommandSelect = (command: CommandData) => {
+    console.log("Selected command:", command.command);
+  };
+  return (
+    <div>
+      <div className="min-h-screen w-full flex justify-center items-center space-x-10">
+        <Table data={data} columns={columns} onRowClick={handleCommandSelect} showFilters={true} />
+      </div>
+      {/* <SelectCommand selectedCommand={selectedCommand} setCommand={setSelectedCommand} /> */}
+    </div>
+  );
+}
+
+export default Commands;

--- a/frontend/mcc/src/pages/Login.tsx
+++ b/frontend/mcc/src/pages/Login.tsx
@@ -1,42 +1,24 @@
+import { API_BASE_URL } from "../utils/api/config";
+
 /**
  * @brief Login component displaying the login page
  * @return tsx element of Login component
  */
 function Login() {
+  const handleLogin = () => {
+    window.location.href = `${API_BASE_URL}/auth/login`;
+  };
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen px-4">
       <div className="w-full max-w-md bg-gray-900/50 backdrop-blur-sm rounded-lg p-8 border border-gray-700/50">
         <h1 className="text-white text-3xl font-bold mb-6 text-center">Login</h1>
-        <form className="space-y-4">
-          <div>
-            <label htmlFor="username" className="text-gray-300 block mb-2">
-              Username
-            </label>
-            <input
-              type="text"
-              id="username"
-              className="w-full bg-gray-800/50 text-white px-4 py-2 rounded-lg border border-gray-600/50 focus:outline-none focus:border-gray-500"
-              placeholder="Enter your username"
-            />
-          </div>
-          <div>
-            <label htmlFor="password" className="text-gray-300 block mb-2">
-              Password
-            </label>
-            <input
-              type="password"
-              id="password"
-              className="w-full bg-gray-800/50 text-white px-4 py-2 rounded-lg border border-gray-600/50 focus:outline-none focus:border-gray-500"
-              placeholder="Enter your password"
-            />
-          </div>
-          <button
-            type="submit"
-            className="w-full bg-white text-black py-2 rounded-lg hover:bg-gray-200 transition-colors mt-6"
-          >
-            Login
-          </button>
-        </form>
+        <button
+          onClick={handleLogin}
+          className="w-full bg-white text-black py-2 rounded-lg hover:bg-gray-200 transition-colors cursor-pointer"
+        >
+          Sign in with Keycloak
+        </button>
       </div>
     </div>
   );

--- a/frontend/mcc/src/utils/api/auth.ts
+++ b/frontend/mcc/src/utils/api/auth.ts
@@ -1,0 +1,6 @@
+import { API_BASE_URL } from "./config";
+
+export async function checkAuth(): Promise<boolean> {
+  const res = await fetch(`${API_BASE_URL}/auth/ping`, { credentials: "include" });
+  return res.ok;
+}

--- a/frontend/mcc/src/utils/api/auth.ts
+++ b/frontend/mcc/src/utils/api/auth.ts
@@ -1,6 +1,10 @@
 import { API_BASE_URL } from "./config";
 
 export async function checkAuth(): Promise<boolean> {
-  const res = await fetch(`${API_BASE_URL}/auth/ping`, { credentials: "include" });
-  return res.ok;
+  try {
+    const res = await fetch(`${API_BASE_URL}/auth/ping`, { credentials: "include" });
+    return res.ok;
+  } catch {
+    return false;
+  }
 }

--- a/frontend/mcc/src/utils/api/config.ts
+++ b/frontend/mcc/src/utils/api/config.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1/mcc";

--- a/template.env
+++ b/template.env
@@ -8,11 +8,15 @@ GS_DATABASE_PORT=5432              # Default PostgreSQL port. Change if needed
 GS_DATABASE_NAME=gs                # Name of the database
 
 # If mcc-realm.json has been synced properly, all keycloak fields can be found there
-KEYCLOAK_URL=http://localhost:8080
+# For the shared remote instance, set both to the remote Keycloak URL instead
+KEYCLOAK_HOST=http://localhost:8080
+KEYCLOAK_EXTERNAL_URL=http://localhost:8080
 KEYCLOAK_REALM=mcc
 KEYCLOAK_CLIENT_ID=ground-station
-KEYCLOAK_CLIENT_SECRET=            # Ctrl/Cmd + F "secret" key in mcc-realm.json
+KEYCLOAK_CLIENT_SECRET=
 KEYCLOAK_CALLBACK_URL=http://localhost:8000/api/v1/mcc/auth/callback
+KEYCLOAK_REDIRECT_URI=http://localhost:5174
+KEYCLOAK_SECURE_COOKIES=false
 
 ARO_AUTH_JWT_SECRET_KEY=
 ARO_AUTH_GOOGLE_CLIENT_ID=


### PR DESCRIPTION
# Purpose
Closes #110.
Right now the MCC auth is not wired to frontend. We need the auth to work on frontend before we can start wiring endpoints.

# New Changes
- Updates Login page to use Keycloak
- Adds AuthContext/AuthProvider and checkAuth helper
- Adds functional login/logout feature
- Re-adds commands page and locks it behind a ProtectedRoute

# Testing
Explain tests that you ran to verify code functionality.
- [ ] I have unit-tested this PR. Otherwise, explain why it cannot be unit-tested.
- [ ] I have tested this PR on a board if the code will run on a board (Only required for firmware developers).
- [ ] I have tested this PR by running the ARO website (Only required if the code will impact the ARO website).
- [x] I have tested this PR by running the MCC website (Only required if the code will impact the MCC website).
- [ ] I have included screenshots of the tests performed below.