### PR TITLE
Add frontend API client functions and lockout helper

### DIFF
--- a/backend/api/backend_setup.py
+++ b/backend/api/backend_setup.py
@@ -15,6 +15,7 @@ from api.v1.mcc.endpoints.auth import mcc_auth_router
 from api.v1.mcc.endpoints.commands import commands_router
 from api.v1.mcc.endpoints.main_commands import main_commands_router
 from api.v1.mcc.endpoints.main_telemetry import main_telemetry_router
+from api.v1.mcc.endpoints.sessions import comms_sessions_router
 from api.v1.mcc.endpoints.status import status_router
 from api.v1.mcc.endpoints.telemetry import telemetry_router
 from api.v1.mcc.endpoints.users import mcc_users_router
@@ -35,6 +36,7 @@ def setup_routes(app: FastAPI) -> None:
     app.include_router(commands_router, prefix=f"{mcc_prefix}/commands")
     app.include_router(telemetry_router, prefix=f"{mcc_prefix}/telemetry")
     app.include_router(aro_requests_router, prefix=f"{mcc_prefix}/requests")
+    app.include_router(comms_sessions_router, prefix=f"{mcc_prefix}/sessions")
     app.include_router(main_commands_router, prefix=f"{mcc_prefix}/main-commands")
     app.include_router(main_telemetry_router, prefix=f"{mcc_prefix}/main-telemetry")
     app.include_router(mcc_auth_router, prefix=f"{mcc_prefix}/auth")

--- a/backend/api/v1/mcc/endpoints/sessions.py
+++ b/backend/api/v1/mcc/endpoints/sessions.py
@@ -1,0 +1,18 @@
+from data.data_wrappers.wrappers import CommsSessionWrapper
+from fastapi import APIRouter
+from mcc_keycloak.client import keycloak
+
+from api.v1.mcc.models.responses import CommsSessionsResponse
+
+comms_sessions_router = APIRouter(tags=["MCC", "Sessions"])
+
+
+@comms_sessions_router.get("/", dependencies=[keycloak.require_auth])
+async def get_all_comms_sessions() -> CommsSessionsResponse:
+    """
+    Retrieve all sessions.
+
+    :return: The list of all sessions.
+    """
+    items = CommsSessionWrapper().get_all()
+    return CommsSessionsResponse(data=items)

--- a/backend/api/v1/mcc/models/responses.py
+++ b/backend/api/v1/mcc/models/responses.py
@@ -2,7 +2,7 @@ from typing import Annotated
 from uuid import UUID
 
 from data.tables.main_tables import MainCommand, MainTelemetry
-from data.tables.transactional_tables import Command
+from data.tables.transactional_tables import Command, CommsSession
 from pydantic import BaseModel, Field
 
 
@@ -34,6 +34,12 @@ class DeleteCommandResponse(BaseModel):
     """Response model confirming a command deletion."""
 
     message: Annotated[str, Field(description="Confirmation message including the deleted command ID")]
+
+
+class CommsSessionsResponse(BaseModel):
+    """Response model wrapping a list of CommsSessions."""
+
+    data: Annotated[list[CommsSession], Field(description="A list containing CommsSession objects")]
 
 
 class MainTelemetriesResponse(BaseModel):

--- a/frontend/mcc/src/App.test.tsx
+++ b/frontend/mcc/src/App.test.tsx
@@ -1,14 +1,18 @@
-import { describe, it } from "vitest";
-import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { render, waitFor, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 
 describe("App", () => {
-  it("should render without crashing", () => {
+  it("should render without crashing", async () => {
     render(
       <BrowserRouter>
         <App />
       </BrowserRouter>,
     );
+
+    await waitFor(() => {
+      expect(screen.getByRole("navigation")).toBeInTheDocument()
+    })
   });
 });

--- a/frontend/mcc/src/App.test.tsx
+++ b/frontend/mcc/src/App.test.tsx
@@ -12,7 +12,7 @@ describe("App", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("navigation")).toBeInTheDocument()
-    })
+      expect(screen.getByRole("navigation")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/mcc/src/__tests__/setup.ts
+++ b/frontend/mcc/src/__tests__/setup.ts
@@ -9,8 +9,8 @@ beforeAll(() => {
       ok: false,
       status: 401,
       json: async () => ({}),
-    })
-  )
+    }),
+  );
   Object.defineProperty(window, "localStorage", {
     value: {
       getItem: vi.fn(),

--- a/frontend/mcc/src/__tests__/setup.ts
+++ b/frontend/mcc/src/__tests__/setup.ts
@@ -3,6 +3,14 @@ import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
 beforeAll(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    })
+  )
   Object.defineProperty(window, "localStorage", {
     value: {
       getItem: vi.fn(),

--- a/frontend/mcc/src/components/Nav.test.tsx
+++ b/frontend/mcc/src/components/Nav.test.tsx
@@ -1,17 +1,13 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import "@testing-library/jest-dom";
 import Nav from "./Nav";
 import { AuthProvider } from "../contexts/AuthContext";
 import { ThemeProvider } from "../contexts/ThemeContext";
 
-vi.mock("../utils/api/auth", () => ({
-  checkAuth: vi.fn().mockResolvedValue(false),
-}))
-
 describe("Nav", () => {
-  it("renders logo", () => {
+  it("renders logo", async () => {
     render(
       <AuthProvider>
         <ThemeProvider>
@@ -21,10 +17,13 @@ describe("Nav", () => {
         </ThemeProvider>
       </AuthProvider>,
     );
-    expect(screen.getByAltText("orbital logo")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByAltText("orbital logo")).toBeInTheDocument();
+    });
   });
 
-  it("renders navigation links", () => {
+  it("renders navigation links", async () => {
     render(
       <AuthProvider>
         <ThemeProvider>
@@ -34,10 +33,13 @@ describe("Nav", () => {
         </ThemeProvider>
       </AuthProvider>,
     );
-    expect(screen.getByText("Dashboard")).toBeInTheDocument();
-    expect(screen.getByText("Commands")).toBeInTheDocument();
-    expect(screen.getByText("ARO Admin")).toBeInTheDocument();
-    expect(screen.getByText("Live Sessions")).toBeInTheDocument();
-    expect(screen.getByText("Login")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("Dashboard")).toBeInTheDocument();
+      expect(screen.getByText("Commands")).toBeInTheDocument();
+      expect(screen.getByText("ARO Admin")).toBeInTheDocument();
+      expect(screen.getByText("Live Sessions")).toBeInTheDocument();
+      expect(screen.getByText("Login")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/mcc/src/components/Nav.test.tsx
+++ b/frontend/mcc/src/components/Nav.test.tsx
@@ -1,10 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import "@testing-library/jest-dom";
 import Nav from "./Nav";
 import { AuthProvider } from "../contexts/AuthContext";
 import { ThemeProvider } from "../contexts/ThemeContext";
+
+vi.mock("../utils/api/auth", () => ({
+  checkAuth: vi.fn().mockResolvedValue(false),
+}))
 
 describe("Nav", () => {
   it("renders logo", () => {

--- a/frontend/mcc/src/utils/api/auth.ts
+++ b/frontend/mcc/src/utils/api/auth.ts
@@ -3,10 +3,7 @@ import { API_BASE_URL } from "./config";
 export class ApiError extends Error {
   status: number;
 
-  constructor(
-    status: number,
-    message: string,
-  ) {
+  constructor(status: number, message: string) {
     super(message);
     this.status = status;
   }

--- a/frontend/mcc/src/utils/api/auth.ts
+++ b/frontend/mcc/src/utils/api/auth.ts
@@ -1,5 +1,33 @@
 import { API_BASE_URL } from "./config";
 
+export class ApiError extends Error {
+  status: number;
+
+  constructor(
+    status: number,
+    message: string,
+  ) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export function jsonHeaders(): HeadersInit {
+  return { "Content-Type": "application/json" };
+}
+
+export async function parseOrThrow<T>(res: Response): Promise<T> {
+  if (res.status === 401) {
+    window.location.href = `${API_BASE_URL}/auth/login`;
+    throw new ApiError(401, "Not authenticated");
+  }
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new ApiError(res.status, body.detail ?? `Request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
 export async function checkAuth(): Promise<boolean> {
   try {
     const res = await fetch(`${API_BASE_URL}/auth/ping`, { credentials: "include" });

--- a/frontend/mcc/src/utils/api/commands.ts
+++ b/frontend/mcc/src/utils/api/commands.ts
@@ -1,0 +1,63 @@
+import { API_BASE_URL } from "./config";
+import { jsonHeaders, parseOrThrow } from "./auth";
+import type { Command } from "../types";
+
+
+interface CommandResponse {
+  data: Command;
+}
+
+interface CommandsResponse {
+  data: Command[];
+}
+
+interface DeleteCommandResponse {
+  message: string;
+}
+
+export async function getCommandsBySession(sessionId: string): Promise<Command[]> {
+  const res = await fetch(`${API_BASE_URL}/commands/session/${sessionId}`, {
+    credentials: "include",
+    headers: jsonHeaders(),
+  });
+  const json = await parseOrThrow<CommandsResponse>(res);
+  return json.data;
+}
+
+export async function createCommand(payload: {
+  type_: number;
+  params?: string;
+  session_id: string;
+}): Promise<Command> {
+  const res = await fetch(`${API_BASE_URL}/commands/`, {
+    method: "POST",
+    credentials: "include",
+    headers: jsonHeaders(),
+    body: JSON.stringify(payload),
+  });
+  const json = await parseOrThrow<CommandResponse>(res);
+  return json.data;
+}
+
+export async function updateCommand(
+  commandId: string,
+  payload: Partial<{ status: string; type_: number; params: string }>,
+): Promise<Command> {
+  const res = await fetch(`${API_BASE_URL}/commands/${commandId}`, {
+    method: "PATCH",
+    credentials: "include",
+    headers: jsonHeaders(),
+    body: JSON.stringify(payload),
+  });
+  const json = await parseOrThrow<CommandResponse>(res);
+  return json.data;
+}
+
+export async function deleteCommand(commandId: string): Promise<DeleteCommandResponse> {
+  const res = await fetch(`${API_BASE_URL}/commands/${commandId}`, {
+    method: "DELETE",
+    credentials: "include",
+    headers: jsonHeaders(),
+  });
+  return parseOrThrow<DeleteCommandResponse>(res);
+}

--- a/frontend/mcc/src/utils/api/commands.ts
+++ b/frontend/mcc/src/utils/api/commands.ts
@@ -2,7 +2,6 @@ import { API_BASE_URL } from "./config";
 import { jsonHeaders, parseOrThrow } from "./auth";
 import type { Command } from "../types";
 
-
 interface CommandResponse {
   data: Command;
 }

--- a/frontend/mcc/src/utils/api/mainCommands.ts
+++ b/frontend/mcc/src/utils/api/mainCommands.ts
@@ -1,0 +1,16 @@
+import { API_BASE_URL } from "./config";
+import { jsonHeaders, parseOrThrow } from "./auth";
+import type { MainCommand } from "../types";
+
+interface MainCommandsResponse {
+  data: MainCommand[];
+}
+
+export async function getMainCommands(): Promise<MainCommand[]> {
+  const res = await fetch(`${API_BASE_URL}/main-commands/`, {
+    credentials: "include",
+    headers: jsonHeaders(),
+  });
+  const json = await parseOrThrow<MainCommandsResponse>(res);
+  return json.data;
+}

--- a/frontend/mcc/src/utils/api/sessions.ts
+++ b/frontend/mcc/src/utils/api/sessions.ts
@@ -1,0 +1,16 @@
+import { API_BASE_URL } from "./config";
+import { jsonHeaders, parseOrThrow } from "./auth";
+import type { Session } from "../types";
+
+interface SessionsResponse {
+  data: Session[];
+}
+
+export async function getSessions(): Promise<Session[]> {
+  const res = await fetch(`${API_BASE_URL}/sessions/`, {
+    credentials: "include",
+    headers: jsonHeaders(),
+  });
+  const json = await parseOrThrow<SessionsResponse>(res);
+  return json.data;
+}

--- a/frontend/mcc/src/utils/lockout.ts
+++ b/frontend/mcc/src/utils/lockout.ts
@@ -1,0 +1,7 @@
+export const SESSION_LOCKOUT_SECONDS = 10;
+
+export function isSessionLockedOut(startTime: string | Date): boolean {
+  const start = typeof startTime === "string" ? new Date(startTime) : startTime;
+  const lockoutStart = new Date(start.getTime() - SESSION_LOCKOUT_SECONDS * 1000);
+  return new Date() >= lockoutStart;
+}


### PR DESCRIPTION
# Purpose
Closes #103.
The frontend API functions do not exist, that is, the commands page is completely non-functional. It needs to be functional. We will call these API functions later when wiring the commands page.

# New Changes
- Adds GET sessions endpoint to backend in preparation for adding commands by session
- Creates API client functions `getCommandsBySession`, `createCommand`, `updateCommand`, `deleteCommand`, `getMainCommands`, `getSessions`
- Adds lockout helper to determine if a session is in lockout at the moment
- Fix some erroring tests

# Testing
Explain tests that you ran to verify code functionality.
- [x] I have unit-tested this PR. Otherwise, explain why it cannot be unit-tested.
- [ ] I have tested this PR on a board if the code will run on a board (Only required for firmware developers).
- [ ] I have tested this PR by running the ARO website (Only required if the code will impact the ARO website).
- [x] I have tested this PR by running the MCC website (Only required if the code will impact the MCC website).
- [ ] I have included screenshots of the tests performed below.