### PR TITLE
image table and response field

### DIFF
--- a/backend/data/tables/transactional_tables.py
+++ b/backend/data/tables/transactional_tables.py
@@ -41,6 +41,7 @@ SESSIONS_TABLE_NAME: Final[str] = "sessions"
 PACKETS_TABLE_NAME: Final[str] = "packets"
 TELEMETRY_TABLE_NAME: Final[str] = "telemetry"
 COMMANDS_TABLE_NAME: Final[str] = "commands"
+IMAGES_TABLE_NAME: Final[str] = "images"
 
 # Transactional data tables
 
@@ -111,6 +112,7 @@ class Command(BaseSQLModel, table=True):
         ondelete="SET NULL",
     )
     sequence_index: int | None = Field(default=None)  # Position of this command within its packet
+    response: str | None = Field(default=None)  # Reply from the OBC, populated on downlink
 
     # table information
     __tablename__ = COMMANDS_TABLE_NAME
@@ -209,4 +211,26 @@ class Packet(BaseSQLModel, table=True):
 
     # table information
     __tablename__ = PACKETS_TABLE_NAME
+    __table_args__ = {"schema": TRANSACTIONAL_SCHEMA_NAME}
+
+
+class Image(BaseSQLModel, table=True):
+    """
+    Holds the information about an image downlinked from the OBC
+    """
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    data: str
+    packet_id: UUID | None = Field(
+        default=None,
+        foreign_key=to_foreign_key_value(TRANSACTIONAL_SCHEMA_NAME, PACKETS_TABLE_NAME),
+        ondelete="SET NULL",
+    )
+    aro_id: UUID | None = Field(
+        default=None,
+        foreign_key=to_foreign_key_value(TRANSACTIONAL_SCHEMA_NAME, ARO_REQUESTS_TABLE_NAME),
+        ondelete="SET NULL",
+    )
+
+    __tablename__ = IMAGES_TABLE_NAME
     __table_args__ = {"schema": TRANSACTIONAL_SCHEMA_NAME}

--- a/backend/migrations/versions/b8e4c02f1d67_add_images_table_and_command_response.py
+++ b/backend/migrations/versions/b8e4c02f1d67_add_images_table_and_command_response.py
@@ -1,0 +1,48 @@
+"""add images table and command response
+
+Adds the transactional.images table holding image data downlinked from the OBC,
+and a nullable response column on transactional.commands for the OBC's reply.
+
+Revision ID: b8e4c02f1d67
+Revises: 551e1cea7b28
+Create Date: 2026-07-16 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b8e4c02f1d67"
+down_revision = "551e1cea7b28"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the images table and the commands.response column."""
+    op.add_column(
+        "commands",
+        sa.Column("response", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        schema="transactional",
+    )
+    op.create_table(
+        "images",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("data", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("packet_id", sa.Uuid(), nullable=True),
+        sa.Column("aro_id", sa.Uuid(), nullable=True),
+        sa.ForeignKeyConstraint(["packet_id"], ["transactional.packets.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["aro_id"], ["transactional.aro_requests.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        schema="transactional",
+    )
+    op.create_index(op.f("ix_transactional_images_id"), "images", ["id"], unique=False, schema="transactional")
+
+
+def downgrade() -> None:
+    """Drop the images table and the commands.response column."""
+    op.drop_index(op.f("ix_transactional_images_id"), table_name="images", schema="transactional")
+    op.drop_table("images", schema="transactional")
+    op.drop_column("commands", "response", schema="transactional")

--- a/backend/python_test/test_tables/test_transactional.py
+++ b/backend/python_test/test_tables/test_transactional.py
@@ -10,6 +10,7 @@ from data.tables.transactional_tables import (
     ARORequest,
     Command,
     CommsSession,
+    Image,
     Packet,
     Telemetry,
 )
@@ -246,7 +247,9 @@ def test_commands_packet_link(db_session: Session, default_comms_session: CommsS
 
     # Commands now link directly to a packet with a sequence index
     id = uuid4()
-    command = Command(id=id, type_=main_command.id, packet_id=packet.id, sequence_index=0, session_id=default_comms_session.id)
+    command = Command(
+        id=id, type_=main_command.id, packet_id=packet.id, sequence_index=0, session_id=default_comms_session.id
+    )
     db_session.add(command)
     db_session.commit()
 
@@ -261,3 +264,91 @@ def test_commands_packet_link(db_session: Session, default_comms_session: CommsS
     db_session.expire_all()
     survivor = db_session.exec(select(Command).where(Command.id == id)).one()
     assert survivor.packet_id is None
+
+
+def test_command_response_defaults_none(db_session: Session, default_comms_session: CommsSession):
+    # Setup the database
+    main_command = MainCommand(id=1, name="Test 1", data_size=1, total_size=2, format="int 7 bytes", params="time")
+    db_session.add(main_command)
+    db_session.commit()
+    db_session.add(default_comms_session)
+    db_session.commit()
+
+    # A command is queued before the OBC has replied, so response starts empty
+    id = uuid4()
+    command = Command(id=id, type_=main_command.id, params="1234567", session_id=default_comms_session.id)
+    db_session.add(command)
+    db_session.commit()
+
+    returned = db_session.exec(select(Command).where(Command.id == id)).one()
+    assert returned.response is None
+
+    # The response is filled in once the downlink carrying it is decoded
+    returned.response = "ACK"
+    db_session.add(returned)
+    db_session.commit()
+    refetched = db_session.exec(select(Command).where(Command.id == id)).one()
+    assert refetched.response == "ACK"
+
+
+def _make_aro_request(db_session: Session) -> ARORequest:
+    """Persist an ARO user and a picture request, returning the request."""
+    user_data = AROUsers(call_sign="123456", email="bob@test.com", first_name="Bob", phone_number="123456789")
+    db_session.add(user_data)
+    db_session.commit()
+
+    aro_request = ARORequest(aro_id=user_data.id, latitude=Decimal(30), longitude=Decimal(40))
+    db_session.add(aro_request)
+    db_session.commit()
+    return aro_request
+
+
+def test_image_basic(db_session: Session, default_comms_session: CommsSession):
+    # Setup the database
+    packet = _make_packet(db_session, default_comms_session)
+    aro_request = _make_aro_request(db_session)
+
+    # Test the images table
+    id = uuid4()
+    image = Image(id=id, data="base64-encoded-pixels", packet_id=packet.id, aro_id=aro_request.id)
+    db_session.add(image)
+    db_session.commit()
+
+    returned = db_session.exec(select(Image).where(Image.id == id)).one()
+    assert returned.data == "base64-encoded-pixels"
+    assert returned.packet_id == packet.id
+    assert returned.aro_id == aro_request.id
+
+
+def test_image_links_default_none(db_session: Session):
+    # An image can be stored before it is matched to a packet or a request
+    id = uuid4()
+    image = Image(id=id, data="base64-encoded-pixels")
+    db_session.add(image)
+    db_session.commit()
+
+    returned = db_session.exec(select(Image).where(Image.id == id)).one()
+    assert returned.packet_id is None
+    assert returned.aro_id is None
+
+
+def test_image_survives_packet_and_request_delete(db_session: Session, default_comms_session: CommsSession):
+    # Setup the database
+    packet = _make_packet(db_session, default_comms_session)
+    aro_request = _make_aro_request(db_session)
+
+    id = uuid4()
+    image = Image(id=id, data="base64-encoded-pixels", packet_id=packet.id, aro_id=aro_request.id)
+    db_session.add(image)
+    db_session.commit()
+
+    # Deleting either link sets it to null but keeps the downlinked image itself
+    db_session.delete(packet)
+    db_session.delete(aro_request)
+    db_session.commit()
+    db_session.expire_all()
+
+    survivor = db_session.exec(select(Image).where(Image.id == id)).one()
+    assert survivor.data == "base64-encoded-pixels"
+    assert survivor.packet_id is None
+    assert survivor.aro_id is None


### PR DESCRIPTION
# Purpose
Kashif commanded me to do it. This pr adds an image table which stores aro id (tracing back to operator), data string field (says text on schema diagram but they should be the same), and packet id. Also added a response field to transactional commands.


# Testing
Vibecoded tests but basically they check that the tables can be populated correctly, and that deleting sessions (for whatever reason) does not erase our image data (yas lets train llms w this data) but instead decouples them from the parent. 

# Outstanding Changes
Once approved I'll toss updated db schema into our notion