### PR TITLE
Wire SendCommand and SelectCommand to real backend data

### DIFF
--- a/backend/api/v1/mcc/endpoints/commands.py
+++ b/backend/api/v1/mcc/endpoints/commands.py
@@ -63,6 +63,7 @@ async def create_command(
             "params": request.params,
             "user_id": current_user.id,
             "session_id": request.session_id,
+            "sequence_index": request.sequence_index,
         }
     )
     return CommandResponse(data=created_command)

--- a/backend/api/v1/mcc/models/requests.py
+++ b/backend/api/v1/mcc/models/requests.py
@@ -13,6 +13,7 @@ class CreateCommandRequest(BaseModel):
         str | None, Field(description="Serialized command parameters matching the main command schema")
     ] = None
     session_id: Annotated[UUID, Field(description="Session this command is scheduled for")]
+    sequence_index: Annotated[int | None, Field(description="Rudimentary send-order hint before packetization")] = None
 
 
 class UpdateCommandRequest(BaseModel):

--- a/frontend/mcc/src/components/ui/alert.tsx
+++ b/frontend/mcc/src/components/ui/alert.tsx
@@ -38,7 +38,7 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-title"
-      className={cn("col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight", className)}
+      className={cn("col-start-2 min-h-4 font-medium tracking-tight", className)}
       {...props}
     />
   );

--- a/frontend/mcc/src/index.css
+++ b/frontend/mcc/src/index.css
@@ -8,7 +8,6 @@
     border-color: var(--border);
   }
   body {
-    overflow: hidden;
     display: flex;
     background-color: var(--background);
     font-family: var(--font-default);

--- a/frontend/mcc/src/pages/Commands.tsx
+++ b/frontend/mcc/src/pages/Commands.tsx
@@ -14,6 +14,8 @@ type CommandRow = {
   status: Command["status"];
   params: string;
   created_at: string;
+  sequence_index: number;
+  response: string;
 };
 
 const statusColors: Record<string, string> = {
@@ -46,6 +48,14 @@ const columns = [
   columnHelper.accessor("created_at", {
     header: "Created",
     cell: (info) => new Date(info.getValue()).toLocaleString(),
+  }),
+  columnHelper.accessor("sequence_index", {
+    header: "Sequence index",
+    cell: (info) => info.getValue().toLocaleString(),
+  }),
+  columnHelper.accessor("response", {
+    header: "Response",
+    cell: (info) => info.getValue(),
   }),
 ];
 
@@ -101,6 +111,8 @@ function Commands() {
     status: cmd.status,
     params: cmd.params ?? "",
     created_at: cmd.created_at,
+    sequence_index: cmd.sequence_index ?? 0,
+    response: cmd.response ?? "",
   }));
 
   const selectedSession = sessions.find((s) => s.id === selectedSessionId) ?? null;
@@ -129,25 +141,20 @@ function Commands() {
 
       <div className="w-full flex justify-center items-start gap-10 pt-6">
         {selectedCommandId && (
-        <SendCommand
-          mainCommand={selectedMainCommand}
-          selectedSessionId={selectedSessionId}
-          sessionStartTime={selectedSession?.start_time ?? null}
-          setSelectedCommandId={setSelectedCommandId}
-          onSubmitted={refetchCommands}
-        />
-      )}
-      <Table data={rows} columns={columns} showFilters={true} />
-      {loading && (
-        <div className="absolute inset-0 flex items-center justify-center bg-background/50 backdrop-blur-sm">
-          <p className="text-gray-400">Loading commands...</p>
+          <SendCommand
+            mainCommand={selectedMainCommand}
+            selectedSessionId={selectedSessionId}
+            sessionStartTime={selectedSession?.start_time ?? null}
+            setSelectedCommandId={setSelectedCommandId}
+            onSubmitted={refetchCommands}
+          />
+        )}
+        <Table data={rows} columns={columns} showFilters={true} />
+        {loading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-background/50 backdrop-blur-sm">
+            <p className="text-gray-400">Loading commands...</p>
           </div>
-      )}
-        {/* {loading ? (
-          <p className="text-gray-400">Loading commands...</p>
-        ) : (
-          <Table data={rows} columns={columns} showFilters={true} />
-        )} */}
+        )}
       </div>
       <SelectCommand
         mainCommands={mainCommands}

--- a/frontend/mcc/src/pages/Commands.tsx
+++ b/frontend/mcc/src/pages/Commands.tsx
@@ -1,7 +1,7 @@
 import { createColumnHelper } from "@tanstack/react-table";
 import Table from "../components/Table";
 import type { Command, MainCommand, Session } from "../utils/types";
-// import SelectCommand from "./components/SelectCommand";
+import SelectCommand from "./SelectCommand";
 // import SendCommand from "./components/SendCommand";
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { getSessionsInRange } from "../utils/api/sessions";
@@ -58,7 +58,7 @@ function Commands() {
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const [mainCommands, setMainCommands] = useState<MainCommand[]>([]);
   const [commands, setCommands] = useState<Command[]>([]);
-  // const [selectedCommandId, setSelectedCommandId] = useState<number | null>(null);
+  const [selectedCommandId, setSelectedCommandId] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -134,7 +134,7 @@ function Commands() {
           <Table data={rows} columns={columns} showFilters={true} />
         )}
       </div>
-      {/* <SelectCommand selectedCommand={selectedCommand} setCommand={setSelectedCommand} /> */}
+      <SelectCommand mainCommands={mainCommands} selectedCommandId={selectedCommandId} setSelectedCommandId={setSelectedCommandId} />
     </div>
   );
 }

--- a/frontend/mcc/src/pages/Commands.tsx
+++ b/frontend/mcc/src/pages/Commands.tsx
@@ -2,7 +2,7 @@ import { createColumnHelper } from "@tanstack/react-table";
 import Table from "../components/Table";
 import type { Command, MainCommand, Session } from "../utils/types";
 import SelectCommand from "./SelectCommand";
-// import SendCommand from "./components/SendCommand";
+import SendCommand from "./SendCommand";
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { getSessionsInRange } from "../utils/api/sessions";
 import { getMainCommands } from "../utils/api/mainCommands";
@@ -103,8 +103,8 @@ function Commands() {
     created_at: cmd.created_at,
   }));
 
-  // const selectedSession = sessions.find((s) => s.id === selectedCommandId) ?? null;
-  // const selectedMainCommand = mainCommands.find((mc) => mc.id === selectedCommandId) ?? null;
+  const selectedSession = sessions.find((s) => s.id === selectedSessionId) ?? null;
+  const selectedMainCommand = mainCommands.find((mc) => mc.id === selectedCommandId) ?? null;
 
   return (
     <div>
@@ -127,14 +127,33 @@ function Commands() {
 
       {error && <p className="text-red-400 text-center mt-4">{error}</p>}
 
-      <div className="min-h-screen w-full flex justify-center items-center space-x-10">
-        {loading ? (
+      <div className="w-full flex justify-center items-start gap-10 pt-6">
+        {selectedCommandId && (
+        <SendCommand
+          mainCommand={selectedMainCommand}
+          selectedSessionId={selectedSessionId}
+          sessionStartTime={selectedSession?.start_time ?? null}
+          setSelectedCommandId={setSelectedCommandId}
+          onSubmitted={refetchCommands}
+        />
+      )}
+      <Table data={rows} columns={columns} showFilters={true} />
+      {loading && (
+        <div className="absolute inset-0 flex items-center justify-center bg-background/50 backdrop-blur-sm">
+          <p className="text-gray-400">Loading commands...</p>
+          </div>
+      )}
+        {/* {loading ? (
           <p className="text-gray-400">Loading commands...</p>
         ) : (
           <Table data={rows} columns={columns} showFilters={true} />
-        )}
+        )} */}
       </div>
-      <SelectCommand mainCommands={mainCommands} selectedCommandId={selectedCommandId} setSelectedCommandId={setSelectedCommandId} />
+      <SelectCommand
+        mainCommands={mainCommands}
+        selectedCommandId={selectedCommandId}
+        setSelectedCommandId={setSelectedCommandId}
+      />
     </div>
   );
 }

--- a/frontend/mcc/src/pages/SelectCommand.tsx
+++ b/frontend/mcc/src/pages/SelectCommand.tsx
@@ -17,7 +17,7 @@ function SelectCommand({
   selectedCommandId,
   setSelectedCommandId,
 }: {
-  mainCommands: MainCommand[]
+  mainCommands: MainCommand[];
   selectedCommandId: number | null;
   setSelectedCommandId: (id: number | null) => void;
 }) {
@@ -41,7 +41,9 @@ function SelectCommand({
           <DropdownMenuCheckboxItem
             key={command.id}
             checked={selectedCommandId === command.id}
-            onCheckedChange={() => setSelectedCommandId(selectedCommandId === command.id ? null : command.id)}
+            onCheckedChange={() =>
+              setSelectedCommandId(selectedCommandId === command.id ? null : command.id)
+            }
           >
             {command.name}
           </DropdownMenuCheckboxItem>

--- a/frontend/mcc/src/pages/SelectCommand.tsx
+++ b/frontend/mcc/src/pages/SelectCommand.tsx
@@ -1,0 +1,54 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import type { MainCommand } from "../utils/types.ts";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+function SelectCommand({
+  mainCommands,
+  selectedCommandId,
+  setSelectedCommandId,
+}: {
+  mainCommands: MainCommand[]
+  selectedCommandId: number | null;
+  setSelectedCommandId: (id: number | null) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          className="fixed bottom-10 left-10 z-10 rounded-full w-15 h-15 flex items-center justify-center hover:border-ring hover:ring-ring/50 hover:ring-[2px]"
+        >
+          <FontAwesomeIcon icon={faPlus} size="xl" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        <DropdownMenuLabel>Commands</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {mainCommands.length === 0 && (
+          <div className="px-2 py-1.5 text-sm text-muted-foreground">No commands available</div>
+        )}
+        {mainCommands.map((command) => (
+          <DropdownMenuCheckboxItem
+            key={command.id}
+            checked={selectedCommandId === command.id}
+            onCheckedChange={() => setSelectedCommandId(selectedCommandId === command.id ? null : command.id)}
+          >
+            {command.name}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export default SelectCommand;

--- a/frontend/mcc/src/pages/SendCommand.tsx
+++ b/frontend/mcc/src/pages/SendCommand.tsx
@@ -1,0 +1,283 @@
+import { useState, type FormEvent } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { Button } from "@/components/ui/button";
+import {
+  Field,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import CustomAlert from "@/components/Alert";
+import type { MainCommand } from "../utils/types";
+import { parseCommandParameters, type CommandParameter } from "../utils/commandParams";
+import { createCommand } from "../utils/api/commands";
+import { ApiError } from "../utils/api/auth";
+import { isSessionLockedOut } from "../utils/lockout";
+
+interface ParameterValues {
+  [key: string]: string;
+}
+
+const SubmitStatus = {
+  None: "NONE",
+  Success: "SUCCESS",
+  InvalidForm: "INVALID_FORM",
+  LockedOut: "LOCKED_OUT",
+  UnknownError: "UNKNOWN_ERROR",
+} as const;
+
+type SubmitStatus = (typeof SubmitStatus)[keyof typeof SubmitStatus];
+
+const submitAlerts: Record<
+  SubmitStatus,
+  { destructive: boolean; title: string; description: string; timeout?: number | null }
+> = {
+  [SubmitStatus.None]: { destructive: false, title: "", description: "" },
+  [SubmitStatus.Success]: {
+    destructive: false,
+    title: "Success, command submitted!",
+    description: "",
+    timeout: 7000,
+  },
+  [SubmitStatus.InvalidForm]: {
+    destructive: true,
+    title: "Form invalid. Please fill in all required fields with valid values.",
+    description: "",
+    timeout: null,
+  },
+  [SubmitStatus.LockedOut]: {
+    destructive: true,
+    title: "Session is locked; commands can't be scheduled this close to session start.",
+    description: "",
+    timeout: null,
+  },
+  [SubmitStatus.UnknownError]: {
+    destructive: true,
+    title: "An unknown error occurred. Please try again.",
+    description: "",
+    timeout: null,
+  },
+};
+
+/**
+ * @brief SendCommand component for displaying and submitting command parameters
+ * @return tsx element of SendCommand component
+ */
+function SendCommand({
+  mainCommand,
+  selectedSessionId,
+  sessionStartTime,
+  setSelectedCommandId,
+  onSubmitted,
+}: {
+  mainCommand: MainCommand | null;
+  selectedSessionId: string | null;
+  sessionStartTime: string | null;
+  setSelectedCommandId: (id: number | null) => void;
+  onSubmitted: () => void;
+}) {
+  const [parameterValues, setParameterValues] = useState<ParameterValues>({});
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [currentSubmitStatus, setCurrentSubmitStatus] = useState<SubmitStatus>(SubmitStatus.None);
+
+  const parameters: CommandParameter[] = mainCommand ? parseCommandParameters(mainCommand) : [];
+  const lockedOut = sessionStartTime ? isSessionLockedOut(sessionStartTime) : false;
+
+  const handleParameterChange = (paramName: string, value: string) => {
+    setParameterValues((prev) => ({ ...prev, [paramName]: value }));
+  };
+
+  // TODO: replace with command-specific validation
+  const validateParameter = (param: CommandParameter, value: string): boolean => {
+    if (!value.trim()) return false;
+
+    switch (param.type) {
+      case "int":
+        return !isNaN(parseInt(value, 10));
+      case "float":
+        return !isNaN(parseFloat(value));
+      case "boolean":
+        return value.toLowerCase() === "true" || value.toLowerCase() === "false";
+      default:
+        return true;
+    }
+  };
+
+  const isFormValid = (): boolean => {
+    if (!mainCommand) return false;
+    return parameters.every((param) => validateParameter(param, parameterValues[param.name] || ""));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    if (!mainCommand || !selectedSessionId || !isFormValid()) {
+      setCurrentSubmitStatus(SubmitStatus.InvalidForm);
+      return;
+    }
+    if (lockedOut) {
+      setCurrentSubmitStatus(SubmitStatus.LockedOut);
+      return;
+    }
+
+    setCurrentSubmitStatus(SubmitStatus.None);
+    setIsSubmitting(true);
+
+    try {
+      const paramsString = parameters.length
+        ? parameters.map((p) => parameterValues[p.name]).join(",")
+        : undefined;
+
+      await createCommand({
+        type_: mainCommand.id,
+        params: paramsString,
+        session_id: selectedSessionId,
+      });
+
+      setCurrentSubmitStatus(SubmitStatus.Success);
+      setParameterValues({});
+      onSubmitted();
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 409) {
+        setCurrentSubmitStatus(SubmitStatus.LockedOut);
+      } else {
+        setCurrentSubmitStatus(SubmitStatus.UnknownError);
+      }
+      console.error("Error submitting command:", error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const renderParameterInput = (param: CommandParameter) => {
+    const value = parameterValues[param.name] || "";
+    const isValid = validateParameter(param, value);
+    const inputId = `param-${param.name}`;
+
+    const baseInputClasses = `
+      w-full px-3 py-2 border rounded-md
+      focus:outline-none focus:ring-2 focus:ring-blue-500
+      ${!isValid && value ? "border-red-500 bg-red-50" : "border-gray-300"}
+    `;
+
+    switch (param.type) {
+      case "boolean":
+        return (
+          <Select value={value} onValueChange={(val) => handleParameterChange(param.name, val)}>
+            <SelectTrigger
+              className={`w-[180px] ${!isValid && value ? "border-red-500 bg-red-50" : "border-gray-300"}`}
+            >
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="true">True</SelectItem>
+              <SelectItem value="false">False</SelectItem>
+            </SelectContent>
+          </Select>
+        );
+
+      case "int":
+      case "float":
+        return (
+          <Input
+            id={inputId}
+            type="number"
+            value={value}
+            onChange={(e) => handleParameterChange(param.name, e.target.value)}
+            className={baseInputClasses}
+            placeholder={param.type === "int" ? "Enter integer" : "Enter decimal number"}
+            step={param.type === "float" ? "any" : "1"}
+          />
+        );
+
+      default:
+        return (
+          <Input
+            id={inputId}
+            type="text"
+            value={value}
+            onChange={(e) => handleParameterChange(param.name, e.target.value)}
+            className={baseInputClasses}
+            placeholder="Enter text"
+          />
+        );
+    }
+  };
+
+  if (!mainCommand) {
+    return null;
+  }
+
+  return (
+    <div className="p-4 space-y-6 bg-card w-96 border rounded-md animate-in zoom-in-75 duration-300 slide-in-from-left-10">
+      {currentSubmitStatus !== SubmitStatus.None && (
+        <CustomAlert
+          destructive={submitAlerts[currentSubmitStatus].destructive}
+          title={submitAlerts[currentSubmitStatus].title}
+          description={submitAlerts[currentSubmitStatus].description}
+          timeout={submitAlerts[currentSubmitStatus].timeout}
+        />
+      )}
+      <form onSubmit={handleSubmit}>
+        <FieldGroup>
+          <FieldSet>
+            <FieldLegend>{mainCommand.name}</FieldLegend>
+            <FieldDescription>
+              Command ID: {mainCommand.id} | Data Size: {mainCommand.data_size} | Total Size:{" "}
+              {mainCommand.total_size} bytes
+            </FieldDescription>
+            <FieldGroup>
+              {parameters.map((param) => {
+                const value = parameterValues[param.name] || "";
+                const isValid = validateParameter(param, value);
+                return (
+                  <Field key={param.name}>
+                    <FieldLabel htmlFor={`param-${param.name}`}>{param.name}</FieldLabel>
+                    {renderParameterInput(param)}
+                    <div
+                      className="transition-all duration-300 overflow-hidden"
+                      style={{ maxHeight: !isValid && value ? "3rem" : "0" }}
+                    >
+                      {!isValid && value && (
+                        <p className="text-sm text-red-600 animate-in fade-in-50 duration-150">
+                          Invalid {param.type} value
+                        </p>
+                      )}
+                    </div>
+                  </Field>
+                );
+              })}
+            </FieldGroup>
+          </FieldSet>
+          <Field orientation="horizontal">
+            <Button type="submit" disabled={!isFormValid() || isSubmitting}>
+              Submit
+              {isSubmitting && <FontAwesomeIcon icon={faSpinner} className="animate-spin" />}
+            </Button>
+            <Button
+              variant="outline"
+              type="button"
+              onClick={() => setSelectedCommandId(null)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+          </Field>
+        </FieldGroup>
+      </form>
+    </div>
+  );
+}
+
+export default SendCommand;

--- a/frontend/mcc/src/pages/SendCommand.tsx
+++ b/frontend/mcc/src/pages/SendCommand.tsx
@@ -88,6 +88,7 @@ function SendCommand({
   onSubmitted: () => void;
 }) {
   const [parameterValues, setParameterValues] = useState<ParameterValues>({});
+  const [sequenceIndex, setSequenceIndex] = useState<string>("");
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [currentSubmitStatus, setCurrentSubmitStatus] = useState<SubmitStatus>(SubmitStatus.None);
 
@@ -143,10 +144,12 @@ function SendCommand({
         type_: mainCommand.id,
         params: paramsString,
         session_id: selectedSessionId,
+        sequence_index: sequenceIndex.trim() ? parseInt(sequenceIndex, 10) : undefined,
       });
 
       setCurrentSubmitStatus(SubmitStatus.Success);
       setParameterValues({});
+      setSequenceIndex("");
       onSubmitted();
     } catch (error) {
       if (error instanceof ApiError && error.status === 409) {
@@ -260,6 +263,16 @@ function SendCommand({
               })}
             </FieldGroup>
           </FieldSet>
+          <Field>
+            <FieldLabel htmlFor="sequence-index">Sequence index (optional)</FieldLabel>
+            <Input
+              id="sequence-index"
+              type="number"
+              value={sequenceIndex}
+              onChange={(e) => setSequenceIndex(e.target.value)}
+              placeholder="e.g. 0, 1, 2..."
+            />
+          </Field>
           <Field orientation="horizontal">
             <Button type="submit" disabled={!isFormValid() || isSubmitting}>
               Submit

--- a/frontend/mcc/src/utils/api/commands.ts
+++ b/frontend/mcc/src/utils/api/commands.ts
@@ -27,6 +27,7 @@ export async function createCommand(payload: {
   type_: number;
   params?: string;
   session_id: string;
+  sequence_index?: number;
 }): Promise<Command> {
   const res = await fetch(`${API_BASE_URL}/commands/`, {
     method: "POST",

--- a/frontend/mcc/src/utils/commandParams.ts
+++ b/frontend/mcc/src/utils/commandParams.ts
@@ -1,0 +1,26 @@
+import type { MainCommand } from "./types";
+
+export interface CommandParameter {
+  name: string;
+  type: "int" | "float" | "boolean" | "string";
+}
+
+/**
+ * Main command params and format are comma-separated strings whose lengths must match.
+ * This parses them into a name and type pair per parameter
+ *
+ * TODO: Improve this logic and document it on the backend
+ */
+export function parseCommandParameters(mainCommand: MainCommand): CommandParameter[] {
+  if (!mainCommand.params || !mainCommand.format) return [];
+
+  const names = mainCommand.params.split(",").map((s) => s.trim());
+  const types = mainCommand.format.split(",").map((s) => s.trim().toLowerCase());
+
+  return names.map((name, i) => {
+    const rawType = types[i] ?? "string";
+    const type: CommandParameter["type"] =
+      rawType === "int" || rawType === "float" || rawType === "boolean" ? rawType : "string";
+    return { name, type };
+  });
+}

--- a/frontend/mcc/src/utils/types.ts
+++ b/frontend/mcc/src/utils/types.ts
@@ -42,6 +42,7 @@ export interface Command {
   created_at: string;
   packet_id: string | null;
   sequence_index: number | null;
+  response: string | null;
 }
 
 export interface Telemetry {


### PR DESCRIPTION
# Purpose
Closes #104.
We need to wire the command creation menu to the backend, this PR does that

# New Changes
- Brings back SendCommand and SelectCommand and wired the backend, also added sequence index and minor improvements
- Adds sequence_index to create command endpoint
- Adds sequence index and response to frontend table

# Outstanding Changes
Testing coverage
