### PR TITLE
Cache DB engine to reuse connection pool instead of creating a new one per call

### DIFF
--- a/backend/data/database/engine.py
+++ b/backend/data/database/engine.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from config.config import settings
 from sqlalchemy import Engine
 from sqlmodel import Session, create_engine, text
@@ -7,26 +9,31 @@ from data.tables.main_tables import MAIN_SCHEMA_NAME
 from data.tables.transactional_tables import TRANSACTIONAL_SCHEMA_NAME
 
 
+@lru_cache(maxsize=1)
 def get_db_engine() -> Engine:
     """
-    Creates the database engine
+    Creates (once) and returns the database engine
+    Cached so the connection pool is reused across requests
 
     :return: engine
     """
-    return create_engine(settings.db.connection_string)
+    return create_engine(
+        settings.db.connection_string,
+        pool_size=5,
+        max_overflow=10,
+        pool_pre_ping=True,
+        pool_recycle=1800,
+    )
 
 
 def get_db_session() -> Session:
     """
-    Creates the database session.
-
-    :warning: This function depends on the `get_db_engine`.
+    Creates a new session bound to the shared engine
 
     :return: session
     """
     engine = get_db_engine()
-    with Session(engine) as session:
-        return session
+    return Session(engine)
 
 
 def _create_schemas(session: Session) -> None:


### PR DESCRIPTION
# Purpose
The database engine being recreated on every call to `get_db_engine()` caused extra latency. This PR caches the DB engine to prevent this.

# New Changes
- Cache engine to create it once and reuse it
- Add pool settings to engine config
- Simplify `get_db_session()` to bind a new session to the cached engine instead of returning from inside a `with` block (which closes the session before the caller uses it)

# Testing
Explain tests that you ran to verify code functionality.
- [x] I have unit-tested this PR. Otherwise, explain why it cannot be unit-tested.
- [ ] I have tested this PR on a board if the code will run on a board (Only required for firmware developers).
- [ ] I have tested this PR by running the ARO website (Only required if the code will impact the ARO website).
- [x] I have tested this PR by running the MCC website (Only required if the code will impact the MCC website).
- [ ] I have included screenshots of the tests performed below.