### PR TITLE
Fix local Keycloak client

### DIFF
--- a/backend/config/keycloak_config.py
+++ b/backend/config/keycloak_config.py
@@ -10,7 +10,7 @@ class KeycloakConfig(BaseSettings):
     admin_password: str = "admin"
     realm: str = "mcc"
     host: str = "http://keycloak:8080"
-    public_url: str
+    public_url: str = "http://localhost:8080"
     client_id: str = "ground-station"
     client_secret: str
     callback_url: str = "http://localhost:8000/api/v1/mcc/auth/callback"

--- a/backend/config/keycloak_config.py
+++ b/backend/config/keycloak_config.py
@@ -10,7 +10,7 @@ class KeycloakConfig(BaseSettings):
     admin_password: str = "admin"
     realm: str = "mcc"
     host: str = "http://keycloak:8080"
-    external_url: str = "http://localhost:8080"
+    public_url: str
     client_id: str = "ground-station"
     client_secret: str
     callback_url: str = "http://localhost:8000/api/v1/mcc/auth/callback"

--- a/backend/mcc_keycloak/client.py
+++ b/backend/mcc_keycloak/client.py
@@ -23,12 +23,6 @@ class KeycloakClient:
             client_id=config.client_id,
             client_secret_key=config.client_secret,
         )
-        self.external_client = KeycloakOpenID(
-            server_url=config.external_url,
-            realm_name=config.realm,
-            client_id=config.client_id,
-            client_secret_key=config.client_secret,
-        )
         self.admin_client = KeycloakAdmin(
             connection=KeycloakOpenIDConnection(
                 server_url=config.host,
@@ -43,10 +37,11 @@ class KeycloakClient:
     @property
     def login_url(self) -> str:
         """Returns keycloak login URL."""
-        return self.external_client.auth_url(
+        url = self.internal_client.auth_url(
             redirect_uri=self.config.callback_url,
             scope="openid profile email",
         )
+        return url.replace(self.config.host, self.config.public_url)
 
     def logout_url(self, id_token: str) -> str:
         """Returns keycloak logout URL."""
@@ -57,7 +52,7 @@ class KeycloakClient:
                 "id_token_hint": id_token,
             }
         )
-        return f"{self.config.external_url}/realms/{self.config.realm}/protocol/openid-connect/logout?{params}"
+        return f"{self.config.public_url}/realms/{self.config.realm}/protocol/openid-connect/logout?{params}"
 
     def get_tokens(self, code: str) -> dict[str, Any]:
         """Makes API call to keycloak service to get user tokens."""

--- a/template.env
+++ b/template.env
@@ -9,11 +9,11 @@ GS_DATABASE_NAME=gs                # Name of the database
 
 # If mcc-realm.json has been synced properly, all keycloak fields can be found there
 # For the shared remote instance, set both to the remote Keycloak URL instead
-KEYCLOAK_HOST=http://localhost:8080
-KEYCLOAK_EXTERNAL_URL=http://localhost:8080
+KEYCLOAK_HOST=http://keycloak:8080
+KEYCLOAK_PUBLIC_URL=http://localhost:8080
 KEYCLOAK_REALM=mcc
 KEYCLOAK_CLIENT_ID=ground-station
-KEYCLOAK_CLIENT_SECRET=
+KEYCLOAK_CLIENT_SECRET=**********
 KEYCLOAK_CALLBACK_URL=http://localhost:8000/api/v1/mcc/auth/callback
 KEYCLOAK_REDIRECT_URI=http://localhost:5174
 KEYCLOAK_SECURE_COOKIES=false


### PR DESCRIPTION
# Purpose
Local Keycloak had a unique error where the internal server would use the external client's auth URL (external URL env var), meanwhile the browser would also use that same URL, and one would always fail. This PR should fix that and also keep it backwards compatible with the remote instance.

# New Changes
- Replaces external_url env var with public_url
- Removes external client, creates login url with public url, and replaces all instances of the host url in the login url with the public url

# Testing
Explain tests that you ran to verify code functionality.
- [x] I have unit-tested this PR. Otherwise, explain why it cannot be unit-tested.
- [ ] I have tested this PR on a board if the code will run on a board (Only required for firmware developers).
- [ ] I have tested this PR by running the ARO website (Only required if the code will impact the ARO website).
- [x] I have tested this PR by running the MCC website (Only required if the code will impact the MCC website).
- [ ] I have included screenshots of the tests performed below.