### PR TITLE
Build Image Test Workflow

### DIFF
--- a/.github/workflows/build_backend.yml
+++ b/.github/workflows/build_backend.yml
@@ -1,0 +1,19 @@
+name: Build Backend Image
+
+on: [push, pull_request]
+
+jobs:
+  build-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Validate Docker build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/Dockerfile.backend
+          push: false

--- a/.github/workflows/keycloak_start.yml
+++ b/.github/workflows/keycloak_start.yml
@@ -1,5 +1,12 @@
 name: Keycloak Startup
-on: [push, pull_request]
+
+on:
+  push:
+    paths:
+      - "backend/app/mcc_keycloak/mcc-realm.json"
+  pull_request:
+    paths:
+      - "backend/app/mcc_keycloak/mcc-realm.json"
 
 jobs:
   keycloak-test:

--- a/.github/workflows/pr_stats.yml
+++ b/.github/workflows/pr_stats.yml
@@ -9,7 +9,6 @@ jobs:
       - name: Run pull request stats
         uses: flowwer-dev/pull-request-stats@master
         with:
-          token: ${{ secrets.ADD_A_PERSONAL_ACCESS_TOKEN }}
           period: 120
           charts: true
           disable-links: false

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,8 +12,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: "recursive"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
@@ -22,8 +20,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install cmake gcc
           python -m pip install --upgrade pip uv
           uv sync --extra dev
 

--- a/.github/workflows/python_validation.yml
+++ b/.github/workflows/python_validation.yml
@@ -12,8 +12,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: 'recursive'
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3


### PR DESCRIPTION
# Purpose
We can now catch docker build errors before changes are pushed to main.

# New Changes
- New GitHub Action workflow to catch docker build failures
- Cleaned up unnecessary steps and keys in existing workflows
- Updated keycloak test workflow to only run when the mcc-realm.json is changed

# Images
N/A

# Outstanding Changes
This PR is done in anticipation for an image publishing workflow. (#139)