### PR TITLE
Decouple keycloak

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,11 +67,13 @@ npm run test      # vitest
 
 ### Docker dev environment
 
-`docker-compose.yml` at the repo root brings up backend + Keycloak + both frontends + db. The backend service reads `.env` at the repo root (not `backend/.env`). Run from the repo root:
+Keycloak is decoupled into its own `docker-compose.keycloak.yml` (mirrors an external Keycloak). `start.sh` brings Keycloak up, waits for the `mcc` realm to import, then starts the main stack. `docker-compose.yml` brings up backend + both frontends + db and reaches Keycloak over `host.docker.internal` — the api service's `extra_hosts: host.docker.internal:host-gateway`. The backend reads `.env` at the repo root (not `backend/.env`). Run from the repo root:
 
 ```sh
-docker compose up --build
+./start.sh          # keycloak stack, then the main stack
 ```
+
+The single `KEYCLOAK_URL` (default `http://host.docker.internal:8080`) must resolve identically from the backend and the browser. The container resolves it via `host-gateway`; for the host browser add `127.0.0.1 host.docker.internal` to `/etc/hosts` (Docker Desktop often adds this already).
 
 ## Architecture notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,13 +67,13 @@ npm run test      # vitest
 
 ### Docker dev environment
 
-Keycloak is decoupled into its own `docker-compose.keycloak.yml` (mirrors an external Keycloak). `start.sh` brings Keycloak up, waits for the `mcc` realm to import, then starts the main stack. `docker-compose.yml` brings up backend + both frontends + db and reaches Keycloak over `host.docker.internal` — the api service's `extra_hosts: host.docker.internal:host-gateway`. The backend reads `.env` at the repo root (not `backend/.env`). Run from the repo root:
+Keycloak is decoupled into its own `docker-compose.keycloak.yml` (mirrors an external Keycloak). `start.sh` brings Keycloak up, waits for the `mcc` realm to import, then starts the main stack. `docker-compose.yml` brings up backend + both frontends + db. The backend reads `.env` at the repo root (not `backend/.env`). Run from the repo root:
 
 ```sh
 ./start.sh          # keycloak stack, then the main stack
 ```
 
-The single `KEYCLOAK_URL` (default `http://host.docker.internal:8080`) must resolve identically from the backend and the browser. The container resolves it via `host-gateway`; for the host browser add `127.0.0.1 host.docker.internal` to `/etc/hosts` (Docker Desktop often adds this already).
+`KEYCLOAK_URL` is a single field defaulting to `http://localhost:8080` — right for a host-run backend (`uv run fastapi dev`), the browser, and CI, so no host-file edits there. The dockerized api service overrides it to `http://host.docker.internal:8080` (via `environment:` + `extra_hosts: host.docker.internal:host-gateway`), mirroring `GS_DATABASE_LOCATION`. Only that full-`docker compose up` path needs `127.0.0.1 host.docker.internal` in the browser's `/etc/hosts` (Docker Desktop often adds it already).
 
 ## Architecture notes
 

--- a/backend/app/config/env_settings/keycloak_config.py
+++ b/backend/app/config/env_settings/keycloak_config.py
@@ -9,8 +9,7 @@ class KeycloakConfig(BaseSettings):
     admin_username: str = "admin"
     admin_password: str = "admin"
     realm: str = "mcc"
-    host: str = "http://keycloak:8080"
-    public_url: str = "http://localhost:8080"
+    url: str = "http://host.docker.internal:8080"
     client_id: str = "ground-station"
     client_secret: str
     callback_url: str = "http://localhost:8000/api/v1/mcc/auth/callback"

--- a/backend/app/config/env_settings/keycloak_config.py
+++ b/backend/app/config/env_settings/keycloak_config.py
@@ -9,7 +9,7 @@ class KeycloakConfig(BaseSettings):
     admin_username: str = "admin"
     admin_password: str = "admin"
     realm: str = "mcc"
-    url: str = "http://host.docker.internal:8080"
+    url: str = "http://localhost:8080"
     client_id: str = "ground-station"
     client_secret: str
     callback_url: str = "http://localhost:8000/api/v1/mcc/auth/callback"

--- a/backend/app/mcc_keycloak/client.py
+++ b/backend/app/mcc_keycloak/client.py
@@ -19,14 +19,14 @@ class KeycloakClient:
     def __init__(self, config: KeycloakConfig) -> None:
         self.config = config
         self.internal_client = KeycloakOpenID(
-            server_url=config.host,
+            server_url=config.url,
             realm_name=config.realm,
             client_id=config.client_id,
             client_secret_key=config.client_secret,
         )
         self.admin_client = KeycloakAdmin(
             connection=KeycloakOpenIDConnection(
-                server_url=config.host,
+                server_url=config.url,
                 realm_name=config.realm,
                 client_id=config.client_id,
                 client_secret_key=config.client_secret,
@@ -38,11 +38,12 @@ class KeycloakClient:
     @property
     def login_url(self) -> str:
         """Returns keycloak login URL."""
-        url = self.internal_client.auth_url(
-            redirect_uri=self.config.callback_url,
-            scope="openid profile email",
+        return str(
+            self.internal_client.auth_url(
+                redirect_uri=self.config.callback_url,
+                scope="openid profile email",
+            )
         )
-        return url.replace(self.config.host, self.config.public_url)
 
     def logout_url(self, id_token: str) -> str:
         """Returns keycloak logout URL."""
@@ -53,7 +54,7 @@ class KeycloakClient:
                 "id_token_hint": id_token,
             }
         )
-        return f"{self.config.public_url}/realms/{self.config.realm}/protocol/openid-connect/logout?{params}"
+        return f"{self.config.url}/realms/{self.config.realm}/protocol/openid-connect/logout?{params}"
 
     def get_tokens(self, code: str) -> dict[str, Any]:
         """Makes API call to keycloak service to get user tokens."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,6 +10,9 @@ os.environ.setdefault("GS_DATABASE_USER", "testuser")
 os.environ.setdefault("GS_DATABASE_PASSWORD", "testpassword")
 os.environ.setdefault("GS_DATABASE_NAME", "testdb")
 
+os.environ.setdefault("KEYCLOAK_URL", "http://localhost:8080")
+os.environ.setdefault("KEYCLOAK_CLIENT_SECRET", "dummy")
+
 import pytest
 from app.data.database.engine import setup_database
 from app.data.models.transactional_models import CommsSession

--- a/backend/tests/test_mcc_authentication.py
+++ b/backend/tests/test_mcc_authentication.py
@@ -3,6 +3,7 @@ import json
 import app.api.v1.mcc.routes.auth as mcc_auth
 from unittest.mock import patch, PropertyMock
 from app.mcc_keycloak.client import KeycloakClient
+from app.config.env_settings.keycloak_config import KeycloakConfig
 from fastapi.testclient import TestClient
 from main import app
 from app.config.env_settings.backend_config import settings
@@ -89,3 +90,17 @@ def test_logout_endpoint(client):
     assert response.status_code == 307
     assert "openid-connect/logout" in response.headers["location"]
     assert response.cookies.get("access_token") == None and response.cookies.get("id_token") == None
+
+
+SINGLE_URL = "http://keycloak.example:8080"
+
+
+def test_logout_url_uses_single_url():
+    """Test that logout_url is built from the single configured Keycloak URL (no internal/public split)."""
+    config = KeycloakConfig(url=SINGLE_URL, client_secret="dummy")
+    client = KeycloakClient(config)
+
+    logout_url = client.logout_url("mock_id_token")
+
+    assert logout_url.startswith(f"{SINGLE_URL}/realms/{config.realm}/protocol/openid-connect/logout")
+    assert "id_token_hint=mock_id_token" in logout_url

--- a/docker-compose.keycloak.yml
+++ b/docker-compose.keycloak.yml
@@ -1,0 +1,32 @@
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:latest
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        /opt/keycloak/bin/kc.sh start-dev --import-realm &
+        until echo > /dev/tcp/localhost/8080; do sleep 2; done
+        sleep 5
+        /opt/keycloak/bin/kcadm.sh config credentials \
+          --server http://localhost:8080 \
+          --realm master \
+          --user mcc-admin \
+          --password uworbital
+        /opt/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE
+        wait
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: mcc-admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: uworbital
+      KC_HEALTH_ENABLED: true
+      # Fixed hostname so the token issuer is stable and identical for both the
+      # browser redirect and the backend backchannel. Must match KEYCLOAK_URL.
+      KC_HOSTNAME: http://host.docker.internal:8080
+      KC_HOSTNAME_STRICT: false
+    ports:
+      - "8080:8080"
+    volumes:
+      - keycloak_data:/opt/keycloak/data
+      - ./backend/app/mcc_keycloak/mcc-realm.json:/opt/keycloak/data/import/mcc-realm.json
+
+volumes:
+  keycloak_data:

--- a/docker-compose.keycloak.yml
+++ b/docker-compose.keycloak.yml
@@ -18,10 +18,6 @@ services:
       KC_BOOTSTRAP_ADMIN_USERNAME: mcc-admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: uworbital
       KC_HEALTH_ENABLED: true
-      # Fixed hostname so the token issuer is stable and identical for both the
-      # browser redirect and the backend backchannel. Must match KEYCLOAK_URL.
-      KC_HOSTNAME: http://host.docker.internal:8080
-      KC_HOSTNAME_STRICT: false
     ports:
       - "8080:8080"
     volumes:

--- a/docker-compose.keycloak.yml
+++ b/docker-compose.keycloak.yml
@@ -23,6 +23,16 @@ services:
     volumes:
       - keycloak_data:/opt/keycloak/data
       - ./backend/app/mcc_keycloak/mcc-realm.json:/opt/keycloak/data/import/mcc-realm.json
+    # Health endpoints are served on the management port 9000 (KC_HEALTH_ENABLED).
+    # The image ships without curl/wget, so probe via bash /dev/tcp socket redirection.
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "{ printf 'GET /health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3; grep -q '200 OK' <&3; } 3<>/dev/tcp/localhost/9000"
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
 
 volumes:
   keycloak_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,30 +14,6 @@ services:
     environment:
       - PYTHONPATH=/app/backend
       - GS_DATABASE_LOCATION=host.docker.internal
-  keycloak:
-    image: quay.io/keycloak/keycloak:latest
-    entrypoint: ["/bin/bash", "-c"]
-    command:
-      - |
-        /opt/keycloak/bin/kc.sh start-dev --import-realm &
-        until echo > /dev/tcp/localhost/8080; do sleep 2; done
-        sleep 5
-        /opt/keycloak/bin/kcadm.sh config credentials \
-          --server http://localhost:8080 \
-          --realm master \
-          --user mcc-admin \
-          --password uworbital
-        /opt/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE
-        wait
-    environment:
-      KC_BOOTSTRAP_ADMIN_USERNAME: mcc-admin
-      KC_BOOTSTRAP_ADMIN_PASSWORD: uworbital
-      KC_HEALTH_ENABLED: true
-    ports:
-      - "8080:8080"
-    volumes:
-      - keycloak_data:/opt/keycloak/data
-      - ./backend/app/mcc_keycloak/mcc-realm.json:/opt/keycloak/data/import/mcc-realm.json
   aro-frontend:
     build:
       context: frontend/aro
@@ -73,5 +49,4 @@ services:
       - postgres_data:/var/lib/postgresql/data
 
 volumes:
-  keycloak_data:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ services:
     environment:
       - PYTHONPATH=/app/backend
       - GS_DATABASE_LOCATION=host.docker.internal
+      # Keycloak runs in docker-compose.keycloak.yml, published on the host. From
+      # inside this container reach it via the host gateway; the browser and a
+      # host-run backend use the localhost default in .env instead.
+      - KEYCLOAK_URL=http://host.docker.internal:8080
   aro-frontend:
     build:
       context: frontend/aro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,6 @@ services:
     environment:
       - PYTHONPATH=/app/backend
       - GS_DATABASE_LOCATION=host.docker.internal
-      # Keycloak runs in docker-compose.keycloak.yml, published on the host. From
-      # inside this container reach it via the host gateway; the browser and a
-      # host-run backend use the localhost default in .env instead.
       - KEYCLOAK_URL=http://host.docker.internal:8080
   aro-frontend:
     build:

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Starts the decoupled Keycloak stack, waits for it to become available, then
+# brings up the main ground-station stack. This mirrors an external Keycloak
+# deployment where the auth service is provisioned independently of the app.
+#
+# Usage: ./start.sh
+set -euo pipefail
+
+KEYCLOAK_COMPOSE="docker-compose.keycloak.yml"
+# Realm discovery endpoint; a 200 here means the realm has finished importing,
+# not just that the port is open.
+KEYCLOAK_READY_URL="http://localhost:8080/realms/mcc/.well-known/openid-configuration"
+
+echo "Starting Keycloak (${KEYCLOAK_COMPOSE})..."
+docker compose -f "${KEYCLOAK_COMPOSE}" up -d --build
+
+echo "Waiting for Keycloak to become available at ${KEYCLOAK_READY_URL}..."
+until curl -sf "${KEYCLOAK_READY_URL}" >/dev/null; do
+  echo "  ...still waiting for Keycloak"
+  sleep 3
+done
+echo "Keycloak is ready."
+
+echo "Starting the main ground-station stack..."
+docker compose up --build

--- a/template.env
+++ b/template.env
@@ -8,10 +8,11 @@ GS_DATABASE_PORT=5432              # Default PostgreSQL port. Change if needed
 GS_DATABASE_NAME=gs                # Name of the database
 
 # If mcc-realm.json has been synced properly, all keycloak fields can be found there
-# Keycloak now runs as a decoupled service (see docker-compose.keycloak.yml). Set
-# this to the single canonical Keycloak URL, reachable identically by the browser
-# and the backend. For the shared remote instance, use the remote Keycloak URL.
-KEYCLOAK_URL=http://host.docker.internal:8080
+# Keycloak now runs as a decoupled service (see docker-compose.keycloak.yml).
+# Default suits a host-run backend and the browser; the dockerized api service
+# overrides this to host.docker.internal in docker-compose.yml. For the shared
+# remote instance, use the remote Keycloak URL.
+KEYCLOAK_URL=http://localhost:8080
 KEYCLOAK_REALM=mcc
 KEYCLOAK_CLIENT_ID=ground-station
 KEYCLOAK_CLIENT_SECRET=**********

--- a/template.env
+++ b/template.env
@@ -8,9 +8,10 @@ GS_DATABASE_PORT=5432              # Default PostgreSQL port. Change if needed
 GS_DATABASE_NAME=gs                # Name of the database
 
 # If mcc-realm.json has been synced properly, all keycloak fields can be found there
-# For the shared remote instance, set both to the remote Keycloak URL instead
-KEYCLOAK_HOST=http://keycloak:8080
-KEYCLOAK_PUBLIC_URL=http://localhost:8080
+# Keycloak now runs as a decoupled service (see docker-compose.keycloak.yml). Set
+# this to the single canonical Keycloak URL, reachable identically by the browser
+# and the backend. For the shared remote instance, use the remote Keycloak URL.
+KEYCLOAK_URL=http://host.docker.internal:8080
 KEYCLOAK_REALM=mcc
 KEYCLOAK_CLIENT_ID=ground-station
 KEYCLOAK_CLIENT_SECRET=**********


### PR DESCRIPTION
# Purpose
Closes #136. https://github.com/UWOrbital/ground-station/issues/136

Decouples Keycloak service from the main Docker Compose setup

# New Changes

Basically did the changes from the ticket:

- Separate Keycloak service into  docker-compose.keycloak.yml
- Update Keycloak client in backend to take one URL instead of two
- Create a start.sh script which starts the Keycloak docker compose, waits for it to become available, then starts the main docker compose
- Update tests and documentation to account for changes

# Images
Attach any images/screenshots related to this PR here.

# Outstanding Changes
If there are non-critical changes (i.e. additional features) that can be made to this feature in the future, indicate them here.
